### PR TITLE
[📦 chore] GraalVM JDK 및 native-image 빌드 환경 적용

### DIFF
--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -12,13 +12,12 @@ jobs:
       - name: 체크아웃
         uses: actions/checkout@v3
 
-      - name: Set up GraalVM JDK 21 with native-image
+      - name: Set up GraalVM JDK 21
         uses: graalvm/setup-graalvm@v1
         with:
           distribution: 'graalvm-community'
           version: '21.0.2'
           java-version: '21'
-          components: 'native-image'
 
       - name: Gradle 캐시 설정
         uses: actions/cache@v3

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -13,10 +13,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up GraalVM JDK 21
-        uses: actions/setup-java@v3
+        uses: graalvm/setup-graalvm@v1
         with:
-          distribution: 'graalvm'
+          version: '21.0.2'
           java-version: '21'
+          distribution: 'graalvm-community'
 
       - name: Install Native Image
         run: gu install native-image

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -19,6 +19,9 @@ jobs:
           java-version: '21'
           distribution: 'graalvm-community'
 
+      - name: Add GraalVM to PATH
+        run: echo "$GRAALVM_HOME/bin" >> $GITHUB_PATH
+
       - name: Install Native Image
         run: gu install native-image
 

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -12,11 +12,14 @@ jobs:
       - name: 체크아웃
         uses: actions/checkout@v3
 
-      - name: Set up Amazon Corretto JDK 21
+      - name: Set up GraalVM JDK 21
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
+          distribution: 'graalvm'
           java-version: '21'
+
+      - name: Install Native Image
+        run: gu install native-image
 
       - name: Gradle 캐시 설정
         uses: actions/cache@v3
@@ -36,3 +39,9 @@ jobs:
 
       - name: ktlint 실행
         run: ./gradlew ktlintCheck
+
+      - name: Native Image Compile (Fail-safe)
+        run: |
+          echo "::group::GraalVM Native Image Build"
+          ./gradlew nativeCompile || echo "⚠️ nativeCompile 실패 - 무시하고 진행합니다"
+          echo "::endgroup::"

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -12,19 +12,13 @@ jobs:
       - name: 체크아웃
         uses: actions/checkout@v3
 
-      - name: Set up GraalVM JDK 21
+      - name: Set up GraalVM JDK 21 with native-image
         uses: graalvm/setup-graalvm@v1
         with:
+          distribution: 'graalvm-community'
           version: '21.0.2'
           java-version: '21'
-          distribution: 'graalvm-community'
-
-      - name: Install Native Image
-        run: |
-          echo "🔧 PATH 설정 중..."
-          export PATH="$GRAALVM_HOME/bin:$PATH"
-          echo "🧩 native-image 설치 시도..."
-          gu install native-image
+          components: 'native-image'
 
       - name: Gradle 캐시 설정
         uses: actions/cache@v3

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -21,7 +21,9 @@ jobs:
 
       - name: Install Native Image
         run: |
+          echo "🔧 PATH 설정 중..."
           export PATH="$GRAALVM_HOME/bin:$PATH"
+          echo "🧩 native-image 설치 시도..."
           gu install native-image
 
       - name: Gradle 캐시 설정

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -43,5 +43,5 @@ jobs:
         continue-on-error: true
         run: |
           echo "::group::GraalVM Native Image Build"
-          ./gradlew nativeCompile
+          ./gradlew nativeCompile --info --stacktrace
           echo "::endgroup::"

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -12,12 +12,13 @@ jobs:
       - name: 체크아웃
         uses: actions/checkout@v3
 
-      - name: Set up GraalVM JDK 21
+      - name: Set up GraalVM JDK 21 with native-image
         uses: graalvm/setup-graalvm@v1
         with:
           distribution: 'graalvm-community'
           version: '21.0.2'
           java-version: '21'
+          components: 'native-image'
 
       - name: Gradle 캐시 설정
         uses: actions/cache@v3
@@ -39,7 +40,8 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: Native Image Compile (Fail-safe)
+        continue-on-error: true
         run: |
           echo "::group::GraalVM Native Image Build"
-          ./gradlew nativeCompile || echo "⚠️ nativeCompile 실패 - 무시하고 진행합니다"
+          ./gradlew nativeCompile
           echo "::endgroup::"

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -19,11 +19,10 @@ jobs:
           java-version: '21'
           distribution: 'graalvm-community'
 
-      - name: Add GraalVM to PATH
-        run: echo "$GRAALVM_HOME/bin" >> $GITHUB_PATH
-
       - name: Install Native Image
-        run: gu install native-image
+        run: |
+          export PATH="$GRAALVM_HOME/bin:$PATH"
+          gu install native-image
 
       - name: Gradle 캐시 설정
         uses: actions/cache@v3


### PR DESCRIPTION
* 기존 Amazon Corretto JDK를 **GraalVM JDK 21**로 교체했습니다.
* `native-image`를 설치한 후, `./gradlew nativeCompile`을 실행하는 **네이티브 이미지 빌드 단계**를 추가했습니다.
* 다만, 해당 작업은 리소스를 많이 사용하기 때문에 **CI 흐름이 중단되지 않도록 `continue-on-error`로 예외를 허용**해두었습니다.
* 기존의 `build`, `test`, `ktlint` 흐름은 **그대로 유지**됩니다. 😊

## 📄 Work Description

* `.github/workflows/DEV-CI.yml` 파일 수정

  * `distribution: 'corretto'` → `'graalvm-community'`로 변경
  * `components: 'native-image'` 옵션으로 `native-image` 설치
  * `./gradlew nativeCompile --info --stacktrace` 실행 단계 추가

    * 이때 실패해도 무시되도록 `continue-on-error: true` 설정 포함

## 💭 Thoughts

* GraalVM 기반으로도 빌드 가능하도록 CI를 확장했습니다.
* 다만 `nativeCompile`은 무거운 작업이므로 **CI 환경에서는 fail-safe 처리**해두었고,
* 추후 필요 시 `nativeRun`, `nativeTest`를 분리해서 도입해보는 것도 고려해볼 수 있을 것 같습니다.

## ✅ Testing Result

* GitHub Actions 상에서 전체 CI 정상 동작 확인했습니다. 🙌
* `nativeCompile` 단계가 실패하더라도 전체 워크플로가 **정상 종료**되는 것을 확인했습니다.

## 🗂 Related Issue
* closed #14
