### PR TITLE
[✨feat] 사용자 도메인 에러 코드 및 커스텀 예외 클래스 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/UserErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/UserErrorCode.kt
@@ -1,0 +1,10 @@
+package com.terning.server.kotlin.domain
+
+import org.springframework.http.HttpStatus
+
+enum class UserErrorCode(
+    val status: HttpStatus,
+    val message: String,
+) {
+    INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 프로필 이미지 입니다."),
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/UserException.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/UserException.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.domain
+
+class UserException(
+    val errorCode: UserErrorCode,
+) : RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/UserErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/UserErrorCode.kt
@@ -1,4 +1,4 @@
-package com.terning.server.kotlin.domain
+package com.terning.server.kotlin.domain.user
 
 import org.springframework.http.HttpStatus
 

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/UserException.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/UserException.kt
@@ -1,4 +1,4 @@
-package com.terning.server.kotlin.domain
+package com.terning.server.kotlin.domain.user
 
 class UserException(
     val errorCode: UserErrorCode,

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -2,7 +2,7 @@ package com.terning.server.kotlin.ui.api
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
-import com.terning.server.kotlin.domain.UserException
+import com.terning.server.kotlin.domain.user.UserException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.terning.server.kotlin.ui.api
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.terning.server.kotlin.domain.UserException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -69,6 +70,14 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."))
+    }
+
+    @ExceptionHandler(UserException::class)
+    fun handleUserException(exception: UserException): ResponseEntity<ApiResponse<Unit>> {
+        logger.error("UserException", exception)
+        return ResponseEntity
+            .status(exception.errorCode.status)
+            .body(ApiResponse.error(exception.errorCode.status, exception.errorCode.message))
     }
 
     private fun MethodArgumentNotValidException.messages(): String =


### PR DESCRIPTION
# 📄 Work Description  
- `UserErrorCode` enum을 생성하여 사용자 도메인에서 발생할 수 있는 에러 코드를 정의했습니다.  
- 각 에러 코드는 `HttpStatus`와 메시지를 포함하고 있어 클라이언트 응답에 활용할 수 있습니다.  
- `UserException` 클래스를 만들어 `UserErrorCode` 기반의 커스텀 예외 처리가 가능하도록 구성했습니다.  
- 전역 예외 처리기(`ExceptionHandler`)에 `UserException`을 처리하는 핸들러 메서드를 추가했습니다.  
- 예외 발생 시 상태 코드와 메시지를 일관되게 전달하도록 `ApiResponse.error`로 응답 포맷을 통일했습니다.

# 💭 Thoughts  
- 앞으로 사용자 도메인에서 발생하는 다양한 예외를 이 구조로 일관성 있게 관리할 수 있을 것 같아요.  
- 에러 메시지와 상태 코드를 한 곳에서 정의하니 유지보수가 훨씬 쉬워질 것으로 기대됩니다 😊  
- 전역 예외 처리기에 `UserException`을 추가함으로써 실제 API 흐름에서도 예외 응답을 통일된 형식으로 제공할 수 있게 되었습니다.  

# ✅ Testing Result  
- 현재는 단순한 정의 구조이므로 단위 테스트는 작성하지 않았습니다.  
- 예외 메시지와 상태 코드가 정확히 매핑되는지 실제 API 흐름에서 통합 테스트로 검증할 예정입니다.  

# 🗂 Related Issue  
- closed #3
