### PR TITLE
[✨feat] Color(Scrap) 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Color.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Color.kt
@@ -1,0 +1,26 @@
+package com.terning.server.kotlin.domain.scrap
+
+enum class Color(
+    val label: String,
+    private val hexCode: String,
+) {
+    RED("red", "ED4E54"),
+    ORANGE("orange", "F3A649"),
+    LIGHT_GREEN("lightgreen", "C4E953"),
+    MINT("mint", "45D0CC"),
+    PURPLE("purple", "9B64E2"),
+    CORAL("coral", "EE7647"),
+    YELLOW("yellow", "F5E660"),
+    GREEN("green", "84D558"),
+    BLUE("blue", "4AA9F2"),
+    PINK("pink", "F260AC"),
+    ;
+
+    fun toHexString(): String = "#$hexCode"
+
+    companion object {
+        fun from(label: String): Color =
+            entries.firstOrNull { it.label == label }
+                ?: throw ScrapException(ScrapErrorCode.INVALID_COLOR)
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Color.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Color.kt
@@ -1,7 +1,7 @@
 package com.terning.server.kotlin.domain.scrap
 
 enum class Color(
-    val label: String,
+    val color: String,
     private val hexCode: String,
 ) {
     RED("red", "ED4E54"),
@@ -19,8 +19,8 @@ enum class Color(
     fun toHexString(): String = "#$hexCode"
 
     companion object {
-        fun from(label: String): Color =
-            entries.firstOrNull { it.label == label }
+        fun from(color: String): Color =
+            entries.firstOrNull { it.color == color }
                 ?: throw ScrapException(ScrapErrorCode.INVALID_COLOR)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapErrorCode.kt
@@ -1,0 +1,10 @@
+package com.terning.server.kotlin.domain.scrap
+
+import org.springframework.http.HttpStatus
+
+enum class ScrapErrorCode(
+    val status: HttpStatus,
+    val message: String,
+) {
+    INVALID_COLOR(HttpStatus.BAD_REQUEST, "유효하지 않은 스크랩 색상입니다."),
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapException.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapException.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.domain.scrap
+
+class ScrapException(
+    val errorCode: ScrapErrorCode,
+) : RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.terning.server.kotlin.ui.api
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.terning.server.kotlin.domain.scrap.ScrapException
 import com.terning.server.kotlin.domain.user.UserException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.http.HttpHeaders
@@ -75,6 +76,14 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(UserException::class)
     fun handleUserException(exception: UserException): ResponseEntity<ApiResponse<Unit>> {
         logger.error("UserException", exception)
+        return ResponseEntity
+            .status(exception.errorCode.status)
+            .body(ApiResponse.error(exception.errorCode.status, exception.errorCode.message))
+    }
+
+    @ExceptionHandler(ScrapException::class)
+    fun handleScrapException(exception: ScrapException): ResponseEntity<ApiResponse<Unit>> {
+        logger.error("ScrapException", exception)
         return ResponseEntity
             .status(exception.errorCode.status)
             .body(ApiResponse.error(exception.errorCode.status, exception.errorCode.message))

--- a/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ColorTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ColorTest.kt
@@ -1,0 +1,41 @@
+package com.terning.server.kotlin.domain.scrap
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ColorTest {
+    @Nested
+    @DisplayName("from(label: String)")
+    inner class From {
+        @Test
+        @DisplayName("정상적인 label을 전달하면 해당 Color를 반환한다")
+        fun returnsColorWhenLabelIsValid() {
+            val color = Color.from("red")
+
+            assertThat(color).isEqualTo(Color.RED)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 label을 전달하면 ScrapException이 발생한다")
+        fun throwsExceptionWhenLabelIsInvalid() {
+            assertThatThrownBy { Color.from("not-a-color") }
+                .isInstanceOf(ScrapException::class.java)
+                .hasMessage(ScrapErrorCode.INVALID_COLOR.message)
+        }
+    }
+
+    @Nested
+    @DisplayName("toHexString()")
+    inner class ToHexString {
+        @Test
+        @DisplayName("HEX 코드 앞에 #을 붙여 반환한다")
+        fun returnsHexWithHashPrefix() {
+            val color = Color.BLUE
+
+            assertThat(color.toHexString()).isEqualTo("#4AA9F2")
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
Scrap 도메인에서 사용되는 색상(Color)을 enum으로 정의하고,  
label 기반의 조회 기능 및 HEX 코드 반환 기능을 구현했습니다.  
또한 유효하지 않은 label 입력 시 적절한 예외가 발생하도록 `ScrapException`과 `ScrapErrorCode`를 함께 설계하였습니다.  
모든 기능은 테스트 코드로 검증을 완료했습니다 😊

---

# 💭 Thoughts  
이번 작업에서 가장 고민했던 부분은 **조회 실패 시 어떤 방식으로 예외를 처리할지**였습니다.  
`Color` enum은 단순한 값 정의를 넘어 도메인적인 의미도 가지기 때문에,  
조회 실패를 일반적인 IllegalArgumentException이 아니라,  
**스크랩 도메인 전용 예외로 명확히 구분하는 방향**이 더 낫겠다고 판단했어요.

또 하나는 `entries.firstOrNull { it.label == label }`처럼  
컬렉션 캐싱 없이도 가독성 있게 작성할 수 있는 enum 활용 방식에 대해 고민해봤습니다.

혹시 이 enum 구조나 예외 처리 방식에서  
불필요하거나 과한 부분, 혹은 더 명확하게 다듬을 수 있는 부분이 있다면 편하게 말씀해 주세요!  
더 좋은 방향이 있다면 꼭 공유받고 싶어요 🙏

---

# ✅ Testing Result  

![스크린샷 2025-05-17 오후 8 56 26](https://github.com/user-attachments/assets/9d97b247-78ef-4870-aaa1-ddf32a3d071e)

---

# 🗂 Related Issue  
- closed #18
