### PR TITLE
[✨feat] 공통 예외 추상화 구조 도입 

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/common/BaseErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/common/BaseErrorCode.kt
@@ -1,0 +1,8 @@
+package com.terning.server.kotlin.domain.common
+
+import org.springframework.http.HttpStatus
+
+interface BaseErrorCode {
+    val status: HttpStatus
+    val message: String
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/common/BaseException.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/common/BaseException.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.domain.common
+
+abstract class BaseException(
+    val errorCode: BaseErrorCode,
+) : RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapErrorCode.kt
@@ -1,10 +1,11 @@
 package com.terning.server.kotlin.domain.scrap
 
+import com.terning.server.kotlin.domain.common.BaseErrorCode
 import org.springframework.http.HttpStatus
 
 enum class ScrapErrorCode(
-    val status: HttpStatus,
-    val message: String,
-) {
+    override val status: HttpStatus,
+    override val message: String,
+) : BaseErrorCode {
     INVALID_COLOR(HttpStatus.BAD_REQUEST, "유효하지 않은 스크랩 색상입니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapException.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapException.kt
@@ -1,5 +1,5 @@
 package com.terning.server.kotlin.domain.scrap
 
-class ScrapException(
-    val errorCode: ScrapErrorCode,
-) : RuntimeException(errorCode.message)
+import com.terning.server.kotlin.domain.common.BaseException
+
+class ScrapException(errorCode: ScrapErrorCode) : BaseException(errorCode)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/UserErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/UserErrorCode.kt
@@ -1,10 +1,11 @@
 package com.terning.server.kotlin.domain.user
 
+import com.terning.server.kotlin.domain.common.BaseErrorCode
 import org.springframework.http.HttpStatus
 
 enum class UserErrorCode(
-    val status: HttpStatus,
-    val message: String,
-) {
+    override val status: HttpStatus,
+    override val message: String,
+) : BaseErrorCode {
     INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 프로필 이미지 입니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/UserException.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/UserException.kt
@@ -1,5 +1,5 @@
 package com.terning.server.kotlin.domain.user
 
-class UserException(
-    val errorCode: UserErrorCode,
-) : RuntimeException(errorCode.message)
+import com.terning.server.kotlin.domain.common.BaseException
+
+class UserException(errorCode: UserErrorCode) : BaseException(errorCode)

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -17,7 +17,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @RestControllerAdvice
 class ExceptionHandler : ResponseEntityExceptionHandler() {
-
     override fun handleHttpMessageNotReadable(
         ex: HttpMessageNotReadableException,
         headers: HttpHeaders,
@@ -33,7 +32,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
 
         logger.error(
             "Handling ${ex::class.simpleName} with status ${HttpStatus.BAD_REQUEST}: $message",
-            ex
+            ex,
         )
 
         return ResponseEntity
@@ -51,7 +50,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
 
         logger.error(
             "Handling ${ex::class.simpleName} with status ${HttpStatus.BAD_REQUEST}: $message",
-            ex
+            ex,
         )
 
         return ResponseEntity
@@ -63,7 +62,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleBadRequestException(exception: RuntimeException): ResponseEntity<ApiResponse<Unit>> {
         logger.error(
             "Handling ${exception::class.simpleName} with status ${HttpStatus.BAD_REQUEST}: ${exception.message}",
-            exception
+            exception,
         )
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -74,7 +73,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleNotFoundException(exception: EntityNotFoundException): ResponseEntity<ApiResponse<Unit>> {
         logger.error(
             "Handling ${exception::class.simpleName} with status ${HttpStatus.NOT_FOUND}: ${exception.message}",
-            exception
+            exception,
         )
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
@@ -85,7 +84,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleGlobalException(exception: Exception): ResponseEntity<ApiResponse<Unit>> {
         logger.error(
             "Handling ${exception::class.simpleName} with status ${HttpStatus.INTERNAL_SERVER_ERROR}: ${exception.message}",
-            exception
+            exception,
         )
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -96,7 +95,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleBaseException(exception: BaseException): ResponseEntity<ApiResponse<Unit>> {
         logger.error(
             "Handling ${exception::class.simpleName} with status ${exception.errorCode.status}: ${exception.errorCode.message}",
-            exception
+            exception,
         )
         return ResponseEntity
             .status(exception.errorCode.status)

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -2,8 +2,7 @@ package com.terning.server.kotlin.ui.api
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
-import com.terning.server.kotlin.domain.scrap.ScrapException
-import com.terning.server.kotlin.domain.user.UserException
+import com.terning.server.kotlin.domain.common.BaseException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -73,17 +72,9 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
             .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."))
     }
 
-    @ExceptionHandler(UserException::class)
-    fun handleUserException(exception: UserException): ResponseEntity<ApiResponse<Unit>> {
-        logger.error("UserException", exception)
-        return ResponseEntity
-            .status(exception.errorCode.status)
-            .body(ApiResponse.error(exception.errorCode.status, exception.errorCode.message))
-    }
-
-    @ExceptionHandler(ScrapException::class)
-    fun handleScrapException(exception: ScrapException): ResponseEntity<ApiResponse<Unit>> {
-        logger.error("ScrapException", exception)
+    @ExceptionHandler(BaseException::class)
+    fun handleBaseException(exception: BaseException): ResponseEntity<ApiResponse<Unit>> {
+        logger.error("BaseException", exception)
         return ResponseEntity
             .status(exception.errorCode.status)
             .body(ApiResponse.error(exception.errorCode.status, exception.errorCode.message))


### PR DESCRIPTION
# 📄 Work Description  
`UserException`과 `ScrapException`을 각각 따로 핸들링하던 기존 구조를 개선하여,  
공통 추상 클래스인 `BaseException` 기반의 단일 핸들러로 통합 처리하도록 리팩터링했습니다.  
예외가 도메인별로 늘어나더라도 Handler에서 개별 등록 없이 일관되게 처리할 수 있도록 구조를 단순화했습니다.

---

# 💭 Thoughts  
기존에는 도메인마다 예외 클래스를 따로 핸들링하다 보니,  
`ExceptionHandler` 클래스의 책임이 점점 커지고 중복 코드가 생길 가능성이 있었어요.  
그래서 예외 구조를 추상화하고, `BaseException`만 처리하면 되도록 핸들러를 통합했습니다.

리뷰하실 때 혹시 이 구조가 과하거나 불필요한 추상화는 아닌지,  
혹은 더 나은 예외 구조나 책임 분리 방식이 있을지 함께 나눠주시면 감사하겠습니다 😊

---

# ✅ Testing Result  
![스크린샷 2025-05-17 오후 9 16 02](https://github.com/user-attachments/assets/af2b6405-e23b-474a-b106-ba0591893a39)


---

# 🗂 Related Issue  
- closed #22 
