### PR TITLE
[✨feat] Scrap(Filter) 구현 

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Scrap.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Scrap.kt
@@ -1,0 +1,53 @@
+package com.terning.server.kotlin.domain.scrap
+
+import com.terning.server.kotlin.domain.common.BaseRootEntity
+import com.terning.server.kotlin.domain.user.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+
+@Entity
+@Table(name = "scraps")
+class Scrap private constructor(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private var color: Color,
+) : BaseRootEntity() {
+    companion object {
+        fun of(
+            user: User,
+            color: Color,
+        ): Scrap = Scrap(user = user, color = color)
+    }
+
+    fun changeColor(to: Color) {
+        this.color = to
+    }
+
+    fun hexColor(): String = color.toHexString()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+        other as Scrap
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Scrap.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Scrap.kt
@@ -22,7 +22,7 @@ class Scrap private constructor(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "userId", nullable = false)
     val user: User,
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)


### PR DESCRIPTION
# 📄 Work Description  
User와 Color를 기반으로 한 `Scrap` 엔티티를 정의했습니다.  
JPA 매핑을 포함한 도메인 설계를 적용했으며, 정적 팩터리 메서드(`of`)를 통해 의미 있는 방식으로 객체를 생성하도록 구성했습니다.  
색상 변경 기능(`changeColor`)과 HEX 문자열 반환 기능도 도메인 메시지로 노출했습니다.

---

# 💭 Thoughts  
Scrap이 생성되는 방식에 대해 고민하다가, 외부 객체(User 등)가 생성 책임을 갖기보단 Scrap 자신이 생성 책임을 갖는 구조가 더 자연스럽다고 판단했습니다.  
따라서 정적 팩터리 메서드를 통해 도메인 생성 책임을 Scrap 내부에 유지했습니다.  
또한 `equals/hashCode`는 ID를 기준으로 정의하여 JPA/Hibernate에서 안전하게 동작하도록 구성했습니다.  
별도로 검증할 도메인 로직이 없기 때문에 테스트는 작성하지 않았습니다.

---

# ✅ Testing Result  
- 현재 도메인 로직이 단순하며 상태 변경 외 검증 로직이 없어 테스트는 생략했습니다.

---

# 🗂 Related Issue  
- closed #24
