### PR TITLE
[✨feat] WorkingPeriod(Filter) 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterErrorCode.kt
@@ -3,7 +3,7 @@ package com.terning.server.kotlin.domain.filter
 import com.terning.server.kotlin.domain.common.BaseErrorCode
 import org.springframework.http.HttpStatus
 
-enum class WorkingPeriodErrorCode(
+enum class FilterErrorCode(
     override val status: HttpStatus,
     override val message: String,
 ) : BaseErrorCode {

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterException.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterException.kt
@@ -2,4 +2,4 @@ package com.terning.server.kotlin.domain.filter
 
 import com.terning.server.kotlin.domain.common.BaseException
 
-class FilterException(errorCode: WorkingPeriodErrorCode) : BaseException(errorCode)
+class FilterException(errorCode: FilterErrorCode) : BaseException(errorCode)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterException.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterException.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.domain.filter
+
+import com.terning.server.kotlin.domain.common.BaseException
+
+class FilterException(errorCode: WorkingPeriodErrorCode) : BaseException(errorCode)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriod.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriod.kt
@@ -12,6 +12,6 @@ enum class WorkingPeriod(
     companion object {
         fun from(period: String): WorkingPeriod =
             entries.firstOrNull { it.period == period }
-                ?: throw FilterException(WorkingPeriodErrorCode.INVALID_WORKING_PERIOD)
+                ?: throw FilterException(FilterErrorCode.INVALID_WORKING_PERIOD)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriod.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriod.kt
@@ -6,7 +6,8 @@ enum class WorkingPeriod(
 ) {
     SHORT_TERM("short", "1개월 ~ 3개월"),
     MID_TERM("middle", "4개월 ~ 6개월"),
-    LONG_TERM("long", "7개월 이상");
+    LONG_TERM("long", "7개월 이상"),
+    ;
 
     companion object {
         fun from(period: String): WorkingPeriod =

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriod.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriod.kt
@@ -1,0 +1,16 @@
+package com.terning.server.kotlin.domain.filter
+
+enum class WorkingPeriod(
+    val period: String,
+    val label: String,
+) {
+    SHORT_TERM("short", "1개월 ~ 3개월"),
+    MID_TERM("middle", "4개월 ~ 6개월"),
+    LONG_TERM("long", "7개월 이상");
+
+    companion object {
+        fun from(period: String): WorkingPeriod =
+            entries.firstOrNull { it.period == period }
+                ?: throw FilterException(WorkingPeriodErrorCode.INVALID_WORKING_PERIOD)
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodErrorCode.kt
@@ -1,0 +1,11 @@
+package com.terning.server.kotlin.domain.filter
+
+import com.terning.server.kotlin.domain.common.BaseErrorCode
+import org.springframework.http.HttpStatus
+
+enum class WorkingPeriodErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : BaseErrorCode {
+    INVALID_WORKING_PERIOD(HttpStatus.BAD_REQUEST, "유효하지 않은 근무 기간입니다."),
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
@@ -9,19 +9,20 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class WorkingPeriodTest {
-
     @Nested
     @DisplayName("from 메서드는")
     inner class From {
-
         @ParameterizedTest(name = "[{index}] period가 \"{0}\"이면 {1} 을(를) 반환한다")
         @CsvSource(
             "short, SHORT_TERM",
             "middle, MID_TERM",
-            "long, LONG_TERM"
+            "long, LONG_TERM",
         )
         @DisplayName("유효한 period가 주어지면 해당 WorkingPeriod를 반환한다")
-        fun validPeriodReturnsWorkingPeriod(period: String, expected: WorkingPeriod) {
+        fun validPeriodReturnsWorkingPeriod(
+            period: String,
+            expected: WorkingPeriod,
+        ) {
             val result = WorkingPeriod.from(period)
 
             assertThat(result).isEqualTo(expected)

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
@@ -1,0 +1,40 @@
+package com.terning.server.kotlin.domain.filter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class WorkingPeriodTest {
+
+    @Nested
+    @DisplayName("from 메서드는")
+    inner class From {
+
+        @ParameterizedTest(name = "[{index}] period가 \"{0}\"이면 {1} 을(를) 반환한다")
+        @CsvSource(
+            "short, SHORT_TERM",
+            "middle, MID_TERM",
+            "long, LONG_TERM"
+        )
+        @DisplayName("유효한 period가 주어지면 해당 WorkingPeriod를 반환한다")
+        fun validPeriodReturnsWorkingPeriod(period: String, expected: WorkingPeriod) {
+            val result = WorkingPeriod.from(period)
+
+            assertThat(result).isEqualTo(expected)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", "invalid", "Short", "LONGTERM", "mid"])
+        @DisplayName("유효하지 않은 period가 주어지면 FilterException을 던진다")
+        fun invalidPeriodThrowsException(invalidPeriod: String) {
+            assertThatThrownBy { WorkingPeriod.from(invalidPeriod) }
+                .isInstanceOfSatisfying(FilterException::class.java) { ex ->
+                    assertThat(ex.errorCode).isEqualTo(WorkingPeriodErrorCode.INVALID_WORKING_PERIOD)
+                }
+        }
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
@@ -34,7 +34,7 @@ class WorkingPeriodTest {
         fun invalidPeriodThrowsException(invalidPeriod: String) {
             assertThatThrownBy { WorkingPeriod.from(invalidPeriod) }
                 .isInstanceOfSatisfying(FilterException::class.java) { ex ->
-                    assertThat(ex.errorCode).isEqualTo(WorkingPeriodErrorCode.INVALID_WORKING_PERIOD)
+                    assertThat(ex.errorCode).isEqualTo(FilterErrorCode.INVALID_WORKING_PERIOD)
                 }
         }
     }


### PR DESCRIPTION
# 📄 Work Description  
- 근무 기간 정보를 다루는 `WorkingPeriod` enum을 도메인에 정의했습니다.  
- 입력 문자열(`period`)을 기준으로 enum 인스턴스를 반환하는 `from()` 메서드를 구현했습니다.  
- 잘못된 입력값 처리 시 `FilterException`을 발생시키며, `WorkingPeriodErrorCode`를 통해 명확한 에러 메시지를 제공합니다.  
- 파라미터 기반 단위 테스트를 통해 정상/비정상 입력 케이스를 모두 검증했습니다.

---

# 💭 Thoughts  
- 기존 `code`라는 추상적인 네이밍보다, 도메인 의미가 드러나는 `period`가 더 적합하다고 판단했습니다.  
- 예외 처리 방식은 기존 Scrap 도메인과 동일하게 설계하여 일관성을 유지했습니다.  
- enum 구조와 테스트 작성 패턴을 다른 필터 값들(`JobType`, `Grade`)에도 동일하게 적용할 예정입니다.

---

# ✅ Testing Result  
![스크린샷 2025-05-17 오후 10 36 36](https://github.com/user-attachments/assets/9dfca48c-79ad-4ca9-a1af-31a2077f43c5)


---

# 🗂 Related Issue  
- closed #26
