### PR TITLE
[✨feat] JobType(Filter) 구현 

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/JobType.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/JobType.kt
@@ -1,0 +1,26 @@
+package com.terning.server.kotlin.domain.filter
+
+import com.terning.server.kotlin.domain.scrap.ScrapErrorCode
+import com.terning.server.kotlin.domain.scrap.ScrapException
+
+enum class JobType(
+    val type: String,
+    val label: String,
+) {
+    TOTAL("total", "전체"),
+    PLAN("plan", "기획/전략"),
+    MARKETING("marketing", "마케팅/홍보"),
+    ADMIN("admin", "사무/회계"),
+    SALES("sales", "인사/영업"),
+    DESIGN("design", "디자인/예술"),
+    IT("it", "개발/IT"),
+    RESEARCH("research", "연구/생산"),
+    ETC("etc", "기타"),
+    ;
+
+    companion object {
+        fun from(type: String): JobType =
+            entries.firstOrNull { it.type.equals(type, ignoreCase = true) }
+                ?: throw ScrapException(ScrapErrorCode.INVALID_JOB_TYPE)
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapErrorCode.kt
@@ -8,4 +8,5 @@ enum class ScrapErrorCode(
     override val message: String,
 ) : BaseErrorCode {
     INVALID_COLOR(HttpStatus.BAD_REQUEST, "유효하지 않은 스크랩 색상입니다."),
+    INVALID_JOB_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 직무 유형입니다."),
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/JobTypeTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/JobTypeTest.kt
@@ -1,0 +1,40 @@
+package com.terning.server.kotlin.domain.filter
+
+import com.terning.server.kotlin.domain.scrap.ScrapException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class JobTypeTest {
+    @ParameterizedTest(name = "입력: {0} → 기대 결과: {1}")
+    @CsvSource(
+        "total, 전체",
+        "plan, 기획/전략",
+        "marketing, 마케팅/홍보",
+        "admin, 사무/회계",
+        "sales, 인사/영업",
+        "design, 디자인/예술",
+        "it, 개발/IT",
+        "research, 연구/생산",
+        "etc, 기타",
+    )
+    @DisplayName("올바른 type 문자열을 넣었을 때, 해당 JobType을 반환한다.")
+    fun `should return JobType when valid type is provided`(
+        type: String,
+        expectedLabel: String,
+    ) {
+        val jobType = JobType.from(type)
+        assertEquals(expectedLabel, jobType.label)
+    }
+
+    @ParameterizedTest
+    @CsvSource("invalid", "unknown", "none", "test")
+    @DisplayName("잘못된 type 문자열을 넣었을 때, 예외를 발생시킨다.")
+    fun `should throw exception when invalid type is provided`(invalidType: String) {
+        assertThrows(ScrapException::class.java) {
+            JobType.from(invalidType)
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- 직무 필터용 `JobType` enum을 새롭게 정의하고, 문자열 입력을 통해 enum을 매핑하는 정적 메서드를 추가했습니다.
- 예외 상황에 대응하기 위해 `INVALID_JOB_TYPE` 에러 코드를 `ScrapErrorCode`에 정의하고, 이를 활용한 예외 처리 로직을 구현했습니다.
- 직무 필터 기능을 보다 안정적으로 제공할 수 있도록 매핑 테스트를 함께 작성했습니다.

# 💭 Thoughts  
- 이번 구현을 통해 추후 직무별 필터링 기능이나 정렬 기능을 손쉽게 확장할 수 있는 기반을 마련하고자 했어요!
- 특히 `JobType.from(type: String)` 메서드를 통해 외부 입력과 내부 도메인 간 매핑을 명확히 분리할 수 있도록 고민했답니다.
- 아직 도메인 로직이 많이 얽혀 있지 않아서 단순하지만, 에러 메시지 처리까지 고려하면서 작게나마 도메인 기반 설계를 적용해보았습니다 😊

# ✅ Testing Result  
![스크린샷 2025-05-18 오전 12 00 04](https://github.com/user-attachments/assets/61d255c0-8e3d-475e-9884-80e6ec438486)


# 🗂 Related Issue  
- closed #28 

