### PR TITLE
[✨feat] Grade(Filter) 구현 

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterErrorCode.kt
@@ -8,4 +8,5 @@ enum class FilterErrorCode(
     override val message: String,
 ) : BaseErrorCode {
     INVALID_WORKING_PERIOD(HttpStatus.BAD_REQUEST, "유효하지 않은 근무 기간입니다."),
+    INVALID_GRADE(HttpStatus.BAD_REQUEST, "유효하지 않은 학년입니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/Grade.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/Grade.kt
@@ -1,0 +1,18 @@
+package com.terning.server.kotlin.domain.filter
+
+enum class Grade(
+    val type: String,
+    val label: String,
+) {
+    FRESHMAN("freshman", "1학년"),
+    SOPHOMORE("sophomore", "2학년"),
+    JUNIOR("junior", "3학년"),
+    SENIOR("senior", "4학년"),
+    ;
+
+    companion object {
+        fun from(type: String): Grade =
+            entries.firstOrNull { it.type.equals(type, ignoreCase = true) }
+                ?: throw FilterException(FilterErrorCode.INVALID_GRADE)
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/GradeTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/GradeTest.kt
@@ -1,0 +1,34 @@
+package com.terning.server.kotlin.domain.filter
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class GradeTest {
+    @ParameterizedTest(name = "입력: {0} → 기대 결과: {1}")
+    @CsvSource(
+        "freshman, 1학년",
+        "sophomore, 2학년",
+        "junior, 3학년",
+        "senior, 4학년",
+    )
+    @DisplayName("올바른 type 문자열을 넣었을 때, 해당 Grade를 반환한다.")
+    fun `should return Grade when valid type is provided`(
+        type: String,
+        expectedLabel: String,
+    ) {
+        val grade = Grade.from(type)
+        assertEquals(expectedLabel, grade.label)
+    }
+
+    @ParameterizedTest
+    @CsvSource("invalid", "fresh", "null", "first")
+    @DisplayName("잘못된 type 문자열을 넣었을 때, 예외를 발생시킨다.")
+    fun `should throw exception when invalid type is provided`(invalidType: String) {
+        assertThrows(FilterException::class.java) {
+            Grade.from(invalidType)
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- Grade(enum)을 구현하여 학년 필터링 기능 추가  
- 각 학년은 `type`, `label` 값을 가지며, 문자열 type으로부터 Grade를 생성하는 정적 메서드 `from()` 제공  
- 유효하지 않은 값에 대해서는 `FilterException(FilterErrorCode.INVALID_GRADE)` 발생  
- 관련 예외 코드(INVALID_GRADE)도 함께 정의  

# 💭 Thoughts  
- 기존 JobType, WorkingPeriod와 네이밍, 설계 방식 통일을 고려하여 작성했습니다.  
- 도메인 예외와 에러 코드 분리도 함께 적용하여 추후 확장에도 유연하게 대응할 수 있도록 구성했어요.  
- enum 설계 시 한눈에 각 학년의 역할이 드러날 수 있도록 `type`/`label` 네이밍에 신경 썼습니다 :)  

# ✅ Testing Result  
![스크린샷 2025-05-18 오전 12 31 32](https://github.com/user-attachments/assets/1ab2255b-b7b4-40ed-84e7-b2547b9a9520)


# 🗂 Related Issue  
- closed #30 
