### PR TITLE
[✨feat] StartDate(Filter) 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/Month.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/Month.kt
@@ -9,11 +9,13 @@ class Month private constructor(
     val value: Int,
 ) {
     init {
-        require(value in 1..12) { INVALID_MONTH_MESSAGE.format(value) }
+        require(value in MIN_MONTH..MAX_MONTH) { INVALID_MONTH_MESSAGE.format(value) }
     }
 
     companion object {
-        private const val INVALID_MONTH_MESSAGE = "월은 1~12 사이여야 합니다. 입력값: %d"
+        private const val MIN_MONTH = 1
+        private const val MAX_MONTH = 12
+        private const val INVALID_MONTH_MESSAGE = "월은 $MIN_MONTH~$MAX_MONTH 사이여야 합니다. 입력값: %d"
 
         fun from(value: Int): Month = Month(value)
     }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/Month.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/Month.kt
@@ -5,7 +5,7 @@ import jakarta.persistence.Embeddable
 
 @Embeddable
 class Month private constructor(
-    @Column(name = "start_month", nullable = false)
+    @Column(nullable = false)
     val value: Int,
 ) {
     init {

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/Month.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/Month.kt
@@ -1,0 +1,32 @@
+package com.terning.server.kotlin.domain.filter
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class Month private constructor(
+    @Column(name = "start_month", nullable = false)
+    val value: Int,
+) {
+    init {
+        require(value in 1..12) { INVALID_MONTH_MESSAGE.format(value) }
+    }
+
+    companion object {
+        private const val INVALID_MONTH_MESSAGE = "월은 1~12 사이여야 합니다. 입력값: %d"
+
+        fun from(value: Int): Month = Month(value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as Month
+        return value == other.value
+    }
+
+    override fun hashCode(): Int = value
+
+    override fun toString(): String = "$value"
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/StartDate.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/StartDate.kt
@@ -8,10 +8,11 @@ import jakarta.persistence.Embedded
 @Embeddable
 class StartDate private constructor(
     @Embedded
-    @AttributeOverride(name = "value", column = Column(name = "start_year"))
+    @AttributeOverride(name = "value", column = Column(name = "start_year", nullable = false))
     val year: Year,
+
     @Embedded
-    @AttributeOverride(name = "value", column = Column(name = "start_month"))
+    @AttributeOverride(name = "value", column = Column(name = "start_month", nullable = false))
     val month: Month,
 ) {
     companion object {
@@ -21,13 +22,8 @@ class StartDate private constructor(
         ): StartDate = StartDate(year, month)
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as StartDate
-        return year == other.year && month == other.month
-    }
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is StartDate && year == other.year && month == other.month)
 
     override fun hashCode(): Int = 31 * year.hashCode() + month.hashCode()
 

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/StartDate.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/StartDate.kt
@@ -10,7 +10,6 @@ class StartDate private constructor(
     @Embedded
     @AttributeOverride(name = "value", column = Column(name = "start_year", nullable = false))
     val year: Year,
-
     @Embedded
     @AttributeOverride(name = "value", column = Column(name = "start_month", nullable = false))
     val month: Month,
@@ -22,8 +21,7 @@ class StartDate private constructor(
         ): StartDate = StartDate(year, month)
     }
 
-    override fun equals(other: Any?): Boolean =
-        this === other || (other is StartDate && year == other.year && month == other.month)
+    override fun equals(other: Any?): Boolean = this === other || (other is StartDate && year == other.year && month == other.month)
 
     override fun hashCode(): Int = 31 * year.hashCode() + month.hashCode()
 

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/StartDate.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/StartDate.kt
@@ -1,0 +1,35 @@
+package com.terning.server.kotlin.domain.filter
+
+import jakarta.persistence.AttributeOverride
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Embedded
+
+@Embeddable
+class StartDate private constructor(
+    @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "start_year"))
+    val year: Year,
+    @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "start_month"))
+    val month: Month,
+) {
+    companion object {
+        fun of(
+            year: Year,
+            month: Month,
+        ): StartDate = StartDate(year, month)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StartDate
+        return year == other.year && month == other.month
+    }
+
+    override fun hashCode(): Int = 31 * year.hashCode() + month.hashCode()
+
+    override fun toString(): String = "${year.value}년 ${month.value}월"
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/Year.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/Year.kt
@@ -5,7 +5,7 @@ import jakarta.persistence.Embeddable
 
 @Embeddable
 class Year private constructor(
-    @Column(name = "start_year", nullable = false)
+    @Column(nullable = false)
     val value: Int,
 ) {
     init {

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/Year.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/Year.kt
@@ -1,0 +1,32 @@
+package com.terning.server.kotlin.domain.filter
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class Year private constructor(
+    @Column(name = "start_year", nullable = false)
+    val value: Int,
+) {
+    init {
+        require(value > 1900) { INVALID_YEAR_MESSAGE.format(value) }
+    }
+
+    companion object {
+        private const val INVALID_YEAR_MESSAGE = "연도는 1900보다 커야 합니다. 입력값: %d"
+
+        fun from(value: Int): Year = Year(value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as Year
+        return value == other.value
+    }
+
+    override fun hashCode(): Int = value
+
+    override fun toString(): String = "$value"
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/GradeTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/GradeTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 class GradeTest {
+
     @ParameterizedTest(name = "입력: {0} → 기대 결과: {1}")
     @CsvSource(
         "freshman, 1학년",
@@ -19,7 +20,10 @@ class GradeTest {
         type: String,
         expectedLabel: String,
     ) {
+        // when
         val grade = Grade.from(type)
+
+        // then
         assertEquals(expectedLabel, grade.label)
     }
 
@@ -27,6 +31,7 @@ class GradeTest {
     @CsvSource("invalid", "fresh", "null", "first")
     @DisplayName("잘못된 type 문자열을 넣었을 때, 예외를 발생시킨다.")
     fun `should throw exception when invalid type is provided`(invalidType: String) {
+        // expect
         assertThrows(FilterException::class.java) {
             Grade.from(invalidType)
         }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/GradeTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/GradeTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 class GradeTest {
-
     @ParameterizedTest(name = "입력: {0} → 기대 결과: {1}")
     @CsvSource(
         "freshman, 1학년",

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/JobTypeTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/JobTypeTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 class JobTypeTest {
+
     @ParameterizedTest(name = "입력: {0} → 기대 결과: {1}")
     @CsvSource(
         "total, 전체",
@@ -25,7 +26,10 @@ class JobTypeTest {
         type: String,
         expectedLabel: String,
     ) {
+        // when
         val jobType = JobType.from(type)
+
+        // then
         assertEquals(expectedLabel, jobType.label)
     }
 
@@ -33,6 +37,7 @@ class JobTypeTest {
     @CsvSource("invalid", "unknown", "none", "test")
     @DisplayName("잘못된 type 문자열을 넣었을 때, 예외를 발생시킨다.")
     fun `should throw exception when invalid type is provided`(invalidType: String) {
+        // expect
         assertThrows(ScrapException::class.java) {
             JobType.from(invalidType)
         }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/JobTypeTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/JobTypeTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 class JobTypeTest {
-
     @ParameterizedTest(name = "입력: {0} → 기대 결과: {1}")
     @CsvSource(
         "total, 전체",

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/MonthTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/MonthTest.kt
@@ -6,16 +6,24 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class MonthTest {
+
     @Test
     @DisplayName("1부터 12 사이 값으로 Month를 생성할 수 있다")
     fun createValidMonth() {
-        val month = Month.from(6)
+        // given
+        val value = 6
+
+        // when
+        val month = Month.from(value)
+
+        // then
         assertThat(month.value).isEqualTo(6)
     }
 
     @Test
     @DisplayName("0 이하 또는 13 이상의 월은 예외가 발생한다")
     fun throwExceptionWhenMonthIsInvalid() {
+        // expect
         assertThrows<IllegalArgumentException> {
             Month.from(0)
         }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/MonthTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/MonthTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class MonthTest {
-
     @Test
     @DisplayName("1부터 12 사이 값으로 Month를 생성할 수 있다")
     fun createValidMonth() {

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/MonthTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/MonthTest.kt
@@ -1,0 +1,26 @@
+package com.terning.server.kotlin.domain.filter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MonthTest {
+    @Test
+    @DisplayName("1부터 12 사이 값으로 Month를 생성할 수 있다")
+    fun createValidMonth() {
+        val month = Month.from(6)
+        assertThat(month.value).isEqualTo(6)
+    }
+
+    @Test
+    @DisplayName("0 이하 또는 13 이상의 월은 예외가 발생한다")
+    fun throwExceptionWhenMonthIsInvalid() {
+        assertThrows<IllegalArgumentException> {
+            Month.from(0)
+        }
+        assertThrows<IllegalArgumentException> {
+            Month.from(13)
+        }
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/StartDateTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/StartDateTest.kt
@@ -1,0 +1,15 @@
+package com.terning.server.kotlin.domain.filter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class StartDateTest {
+    @Test
+    @DisplayName("Year와 Month로 StartDate를 생성할 수 있다")
+    fun createStartDateWithYearAndMonth() {
+        val startDate = StartDate.of(Year.from(2023), Month.from(5))
+        assertThat(startDate.year.value).isEqualTo(2023)
+        assertThat(startDate.month.value).isEqualTo(5)
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/StartDateTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/StartDateTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class StartDateTest {
-
     @Test
     @DisplayName("Year와 Month로 StartDate를 생성할 수 있다")
     fun createStartDateWithYearAndMonth() {

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/StartDateTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/StartDateTest.kt
@@ -5,10 +5,18 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class StartDateTest {
+
     @Test
     @DisplayName("Year와 Month로 StartDate를 생성할 수 있다")
     fun createStartDateWithYearAndMonth() {
-        val startDate = StartDate.of(Year.from(2023), Month.from(5))
+        // given
+        val year = Year.from(2023)
+        val month = Month.from(5)
+
+        // when
+        val startDate = StartDate.of(year, month)
+
+        // then
         assertThat(startDate.year.value).isEqualTo(2023)
         assertThat(startDate.month.value).isEqualTo(5)
     }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
@@ -9,9 +9,11 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class WorkingPeriodTest {
+
     @Nested
     @DisplayName("from 메서드는")
     inner class From {
+
         @ParameterizedTest(name = "[{index}] period가 \"{0}\"이면 {1} 을(를) 반환한다")
         @CsvSource(
             "short, SHORT_TERM",
@@ -23,8 +25,10 @@ class WorkingPeriodTest {
             period: String,
             expected: WorkingPeriod,
         ) {
+            // when
             val result = WorkingPeriod.from(period)
 
+            // then
             assertThat(result).isEqualTo(expected)
         }
 
@@ -32,6 +36,7 @@ class WorkingPeriodTest {
         @ValueSource(strings = ["", "invalid", "Short", "LONGTERM", "mid"])
         @DisplayName("유효하지 않은 period가 주어지면 FilterException을 던진다")
         fun invalidPeriodThrowsException(invalidPeriod: String) {
+            // expect
             assertThatThrownBy { WorkingPeriod.from(invalidPeriod) }
                 .isInstanceOfSatisfying(FilterException::class.java) { ex ->
                     assertThat(ex.errorCode).isEqualTo(FilterErrorCode.INVALID_WORKING_PERIOD)

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/WorkingPeriodTest.kt
@@ -9,11 +9,9 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class WorkingPeriodTest {
-
     @Nested
     @DisplayName("from 메서드는")
     inner class From {
-
         @ParameterizedTest(name = "[{index}] period가 \"{0}\"이면 {1} 을(를) 반환한다")
         @CsvSource(
             "short, SHORT_TERM",

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/YearTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/YearTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class YearTest {
-
     @Test
     @DisplayName("유효한 연도 값으로 Year를 생성할 수 있다")
     fun createValidYear() {

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/YearTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/YearTest.kt
@@ -6,16 +6,24 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class YearTest {
+
     @Test
     @DisplayName("유효한 연도 값으로 Year를 생성할 수 있다")
     fun createValidYear() {
-        val year = Year.from(2025)
+        // given
+        val value = 2025
+
+        // when
+        val year = Year.from(value)
+
+        // then
         assertThat(year.value).isEqualTo(2025)
     }
 
     @Test
     @DisplayName("1900년 이하의 연도는 예외가 발생한다")
     fun throwExceptionWhenYearIsTooSmall() {
+        // expect
         assertThrows<IllegalArgumentException> {
             Year.from(1899)
         }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/YearTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/YearTest.kt
@@ -1,0 +1,23 @@
+package com.terning.server.kotlin.domain.filter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class YearTest {
+    @Test
+    @DisplayName("유효한 연도 값으로 Year를 생성할 수 있다")
+    fun createValidYear() {
+        val year = Year.from(2025)
+        assertThat(year.value).isEqualTo(2025)
+    }
+
+    @Test
+    @DisplayName("1900년 이하의 연도는 예외가 발생한다")
+    fun throwExceptionWhenYearIsTooSmall() {
+        assertThrows<IllegalArgumentException> {
+            Year.from(1899)
+        }
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ColorTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ColorTest.kt
@@ -7,20 +7,28 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class ColorTest {
-    @Nested
-    @DisplayName("from(label: String)")
-    inner class From {
-        @Test
-        @DisplayName("정상적인 label을 전달하면 해당 Color를 반환한다")
-        fun returnsColorWhenLabelIsValid() {
-            val color = Color.from("red")
 
+    @Nested
+    @DisplayName("from(color: String)")
+    inner class From {
+
+        @Test
+        @DisplayName("정상적인 color 문자열을 전달하면 해당 Color를 반환한다")
+        fun returnsColorWhenColorIsValid() {
+            // given
+            val input = "red"
+
+            // when
+            val color = Color.from(input)
+
+            // then
             assertThat(color).isEqualTo(Color.RED)
         }
 
         @Test
-        @DisplayName("존재하지 않는 label을 전달하면 ScrapException이 발생한다")
-        fun throwsExceptionWhenLabelIsInvalid() {
+        @DisplayName("존재하지 않는 color 문자열을 전달하면 ScrapException이 발생한다")
+        fun throwsExceptionWhenColorIsInvalid() {
+            // expect
             assertThatThrownBy { Color.from("not-a-color") }
                 .isInstanceOf(ScrapException::class.java)
                 .hasMessage(ScrapErrorCode.INVALID_COLOR.message)
@@ -30,12 +38,18 @@ class ColorTest {
     @Nested
     @DisplayName("toHexString()")
     inner class ToHexString {
+
         @Test
         @DisplayName("HEX 코드 앞에 #을 붙여 반환한다")
         fun returnsHexWithHashPrefix() {
+            // given
             val color = Color.BLUE
 
-            assertThat(color.toHexString()).isEqualTo("#4AA9F2")
+            // when
+            val hex = color.toHexString()
+
+            // then
+            assertThat(hex).isEqualTo("#4AA9F2")
         }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ColorTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ColorTest.kt
@@ -7,11 +7,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class ColorTest {
-
     @Nested
     @DisplayName("from(color: String)")
     inner class From {
-
         @Test
         @DisplayName("정상적인 color 문자열을 전달하면 해당 Color를 반환한다")
         fun returnsColorWhenColorIsValid() {
@@ -38,7 +36,6 @@ class ColorTest {
     @Nested
     @DisplayName("toHexString()")
     inner class ToHexString {
-
         @Test
         @DisplayName("HEX 코드 앞에 #을 붙여 반환한다")
         fun returnsHexWithHashPrefix() {


### PR DESCRIPTION
# 📄 Work Description  
- 근무 시작일을 의미하는 VO `StartDate`를 구현했습니다.  
- `StartDate`는 내부적으로 `Year`와 `Month` VO를 조합해 구성됩니다.  
- 각각의 VO는 생성 시 유효성 검사를 포함하고, JPA `@Embeddable`로 설계되어 도메인에 안전하게 통합됩니다.  
- VO 간 중첩 매핑을 위해 `@Embedded`, `@AttributeOverride`를 활용해 컬럼명을 명시적으로 지정했습니다.

# 💭 Thoughts  
- 단순히 `Int`로 처리하던 연도와 월 값을 각각 `Year`, `Month` VO로 분리함으로써 도메인 내 의미를 명확히 표현할 수 있었습니다.  
- 각 VO는 스스로 유효성을 검증하고, 값 객체로서 동일성 비교가 가능하도록 구현되어 책임이 명확히 분리되었습니다.  
- 특히 `StartDate`라는 VO로 두 값을 묶음으로써, 단순 값 조합 이상의 의미(근무 시작일)를 코드 레벨에서 드러낼 수 있게 되었고, 이후 `GraduationDate`, `EndDate` 등 다양한 날짜 표현에 일관된 구조로 확장할 수 있는 기반이 되었습니다.  
- `Year`와 `Month`를 개별 VO로 만든 이유는 재사용 가능성과 검증 책임 분리 때문이며, 이를 조합해 `StartDate`라는 유의미한 도메인 객체를 구성하는 방향이 도메인 응집도 측면에서 적절하다고 판단했습니다.

# ✅ Testing Result  
![스크린샷 2025-05-18 오전 1 06 33](https://github.com/user-attachments/assets/a398acbf-02f2-4bff-a4b9-214be4d975e4)


# 🗂 Related Issue  
- closes #32
