### PR TITLE
[✨feat] Auth 구현 

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -14,9 +14,21 @@ class Auth private constructor(
     @JoinColumn(name = "userId", nullable = false)
     val user: User,
     @Column(length = 255)
-    val authId: String,
+    private val authId: String,
     @Column(length = 12)
-    val authType: AuthType,
+    private val authType: AuthType,
     @Column(length = 255)
-    val refreshToken: String,
-) : BaseRootEntity()
+    private var refreshToken: String?,
+) : BaseRootEntity() {
+    fun updateRefreshToken(newRefreshToken: String) {
+        this.refreshToken = newRefreshToken
+    }
+
+    fun resetRefreshToken() {
+        try{
+            this.refreshToken = null
+        }catch (e :Exception) {
+          //  throw
+        }
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -7,13 +7,13 @@ import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.Table
-import jakarta.persistence.OneToOne
-import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
 
 @Entity
 @Table(name = "auth")

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -1,0 +1,22 @@
+package com.terning.server.kotlin.domain.auth
+
+import com.terning.server.kotlin.domain.common.BaseRootEntity
+import com.terning.server.kotlin.domain.user.User
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "auth")
+class Auth private constructor(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    val user: User,
+    @Column(length = 255)
+    val authId: String,
+    @Column(length = 12)
+    val authType: AuthType,
+    @Column(length = 255)
+    val refreshToken: String,
+) : BaseRootEntity()

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -25,10 +25,10 @@ class Auth private constructor(
     }
 
     fun resetRefreshToken() {
-        try{
+        try {
             this.refreshToken = null
-        }catch (e :Exception) {
-          //  throw
+        } catch (e: Exception) {
+            throw AuthException(AuthErrorCode.FAILED_REFRESH_TOKEN_RESET)
         }
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -2,7 +2,18 @@ package com.terning.server.kotlin.domain.auth
 
 import com.terning.server.kotlin.domain.common.BaseRootEntity
 import com.terning.server.kotlin.domain.user.User
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.OneToOne
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
 
 @Entity
 @Table(name = "auth")

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -26,9 +26,9 @@ class Auth private constructor(
     @Column(length = 12)
     private var authType: AuthType,
     @Column(length = 255)
-    private var refreshToken: String?,
+    private var refreshToken: RefreshToken?,
 ) : BaseRootEntity() {
-    fun updateRefreshToken(newRefreshToken: String) {
+    fun updateRefreshToken(newRefreshToken: RefreshToken) {
         this.refreshToken = newRefreshToken
     }
 

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -2,6 +2,7 @@ package com.terning.server.kotlin.domain.auth
 
 import com.terning.server.kotlin.domain.common.BaseRootEntity
 import com.terning.server.kotlin.domain.user.User
+import jakarta.persistence.AttributeOverride
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
@@ -25,12 +26,14 @@ class Auth private constructor(
     @JoinColumn(name = "userId", nullable = false)
     val user: User,
     @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "authId"))
     private var authId: AuthId,
     @Enumerated(EnumType.STRING)
     @Column(length = 12)
     private var authType: AuthType,
     @Embedded
-    private var refreshToken: RefreshToken?,
+    @AttributeOverride(name = "value", column = Column(name = "refreshToken"))
+    private var refreshToken: RefreshToken,
 ) : BaseRootEntity() {
     fun updateRefreshToken(newRefreshToken: RefreshToken) {
         this.refreshToken = newRefreshToken
@@ -38,7 +41,7 @@ class Auth private constructor(
 
     fun resetRefreshToken() {
         try {
-            this.refreshToken = null
+            this.refreshToken = RefreshToken(null)
         } catch (e: Exception) {
             throw AuthException(AuthErrorCode.FAILED_REFRESH_TOKEN_RESET)
         }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -14,9 +14,9 @@ class Auth private constructor(
     @JoinColumn(name = "userId", nullable = false)
     val user: User,
     @Column(length = 255)
-    private val authId: String,
+    private var authId: String,
     @Column(length = 12)
-    private val authType: AuthType,
+    private var authType: AuthType,
     @Column(length = 255)
     private var refreshToken: String?,
 ) : BaseRootEntity() {

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -2,15 +2,7 @@ package com.terning.server.kotlin.domain.auth
 
 import com.terning.server.kotlin.domain.common.BaseRootEntity
 import com.terning.server.kotlin.domain.user.User
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToOne
-import jakarta.persistence.Table
+import jakarta.persistence.*
 
 @Entity
 @Table(name = "auth")
@@ -21,11 +13,11 @@ class Auth private constructor(
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", nullable = false)
     val user: User,
-    @Column(length = 255)
-    private var authId: String,
+    @Embedded
+    private var authId: AuthId,
     @Column(length = 12)
     private var authType: AuthType,
-    @Column(length = 255)
+    @Embedded
     private var refreshToken: RefreshToken?,
 ) : BaseRootEntity() {
     fun updateRefreshToken(newRefreshToken: RefreshToken) {

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -15,6 +15,7 @@ class Auth private constructor(
     val user: User,
     @Embedded
     private var authId: AuthId,
+    @Enumerated(EnumType.STRING)
     @Column(length = 12)
     private var authType: AuthType,
     @Embedded

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -2,7 +2,15 @@ package com.terning.server.kotlin.domain.auth
 
 import com.terning.server.kotlin.domain.common.BaseRootEntity
 import com.terning.server.kotlin.domain.user.User
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
 
 @Entity
 @Table(name = "auth")

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthErrorCode.kt
@@ -8,6 +8,7 @@ enum class AuthErrorCode(
     override val message: String,
 ) : BaseErrorCode {
     INVALID_TOKEN(status = HttpStatus.UNAUTHORIZED, message = "유효하지 않은 토큰입니다."),
+    FAILED_REFRESH_TOKEN_RESET(status = HttpStatus.BAD_REQUEST, message = "리프레쉬 토큰 초기화에 실패하였습니다"),
     ;
 
     fun getErrorMessage(): String = message

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthErrorCode.kt
@@ -8,7 +8,7 @@ enum class AuthErrorCode(
     override val message: String,
 ) : BaseErrorCode {
     INVALID_TOKEN(status = HttpStatus.UNAUTHORIZED, message = "유효하지 않은 토큰입니다."),
-    FAILED_REFRESH_TOKEN_RESET(status = HttpStatus.BAD_REQUEST, message = "리프레쉬 토큰 초기화에 실패하였습니다"),
+    FAILED_REFRESH_TOKEN_RESET(status = HttpStatus.BAD_REQUEST, message = "리프레시 토큰 초기화에 실패하였습니다"),
     ;
 
     fun getErrorMessage(): String = message

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthId.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthId.kt
@@ -4,7 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 
 @Embeddable
-data class AuthId (
+data class AuthId(
     @Column(length = 255)
-    val value: String
+    val value: String,
 )

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthId.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthId.kt
@@ -1,0 +1,10 @@
+package com.terning.server.kotlin.domain.auth
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class AuthId (
+    @Column(length = 255)
+    val value: String
+)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/RefreshToken.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/RefreshToken.kt
@@ -6,5 +6,5 @@ import jakarta.persistence.Embeddable
 @Embeddable
 data class RefreshToken(
     @Column(length = 255)
-    val value: String,
+    val value: String?,
 )

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/RefreshToken.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/RefreshToken.kt
@@ -1,0 +1,10 @@
+package com.terning.server.kotlin.domain.auth
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class RefreshToken(
+    @Column(length = 255)
+    val value: String,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.terning.server.kotlin.domain.auth.AuthException
 import com.terning.server.kotlin.domain.common.BaseException
+import com.terning.server.kotlin.domain.auth.AuthException
+import com.terning.server.kotlin.domain.user.UserException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.terning.server.kotlin.domain.auth.AuthException
 import com.terning.server.kotlin.domain.common.BaseException
-import com.terning.server.kotlin.domain.auth.AuthException
-import com.terning.server.kotlin.domain.user.UserException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus


### PR DESCRIPTION
# 📄 Work Description  
-  Auth 엔티티를 구현했습니다.
- BaseRootEntity를 상속받아 공통 엔티티의 기능을 유지했습니다.
- 리프레시 토큰 초기화 오류를 추가하였습니다.

# 💭 Thoughts 
- `refreshToken`의 경우 Nullalbe하기 때문에 타입을 `String?`으로 나타내주었습니다!

# ✅ Testing Result  
- 별도의 테스트는 작성하지 않았습니다.

# 🗂 Related Issue  
- closed #37 
