### PR TITLE
[✨feat] ScrapCount VO 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthErrorCode.kt
@@ -13,4 +13,3 @@ enum class AuthErrorCode(
 
     fun getErrorMessage(): String = message
 }
-

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthErrorCode.kt
@@ -13,3 +13,4 @@ enum class AuthErrorCode(
 
     fun getErrorMessage(): String = message
 }
+

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/Deadline.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/Deadline.kt
@@ -7,7 +7,6 @@ import java.time.LocalDate
 class Deadline private constructor(
     val value: LocalDate,
 ) {
-
     fun isOver(today: LocalDate = LocalDate.now()): Boolean = value.isBefore(today)
 
     override fun equals(other: Any?): Boolean = other is Deadline && value == other.value

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/Deadline.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/Deadline.kt
@@ -7,14 +7,6 @@ import java.time.LocalDate
 class Deadline private constructor(
     val value: LocalDate,
 ) {
-    companion object {
-        fun from(value: LocalDate): Deadline {
-            require(value.isAfter(LocalDate.of(2025, 1, 1))) {
-                "마감일은 2025년 이후여야 합니다."
-            }
-            return Deadline(value)
-        }
-    }
 
     fun isOver(today: LocalDate = LocalDate.now()): Boolean {
         return value.isBefore(today)
@@ -25,4 +17,13 @@ class Deadline private constructor(
     override fun hashCode(): Int = value.hashCode()
 
     override fun toString(): String = value.toString()
+
+    companion object {
+        fun from(value: LocalDate): Deadline {
+            require(value.isAfter(LocalDate.of(2025, 1, 1))) {
+                "마감일은 2025년 이후여야 합니다."
+            }
+            return Deadline(value)
+        }
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/Deadline.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/Deadline.kt
@@ -8,9 +8,7 @@ class Deadline private constructor(
     val value: LocalDate,
 ) {
 
-    fun isOver(today: LocalDate = LocalDate.now()): Boolean {
-        return value.isBefore(today)
-    }
+    fun isOver(today: LocalDate = LocalDate.now()): Boolean = value.isBefore(today)
 
     override fun equals(other: Any?): Boolean = other is Deadline && value == other.value
 
@@ -19,10 +17,11 @@ class Deadline private constructor(
     override fun toString(): String = value.toString()
 
     companion object {
+        private val MIN_DEADLINE_DATE: LocalDate = LocalDate.of(2024, 1, 1)
+        private val ERROR_MESSAGE = "마감일은 $MIN_DEADLINE_DATE 이후여야 합니다."
+
         fun from(value: LocalDate): Deadline {
-            require(value.isAfter(LocalDate.of(2025, 1, 1))) {
-                "마감일은 2025년 이후여야 합니다."
-            }
+            require(value.isAfter(MIN_DEADLINE_DATE)) { ERROR_MESSAGE }
             return Deadline(value)
         }
     }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/ScrapCount.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/ScrapCount.kt
@@ -1,0 +1,33 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class ScrapCount private constructor(
+    val value: Int,
+) {
+    init {
+        require(value >= MIN_VALUE) { INVALID_SCRAP_COUNT_MESSAGE }
+    }
+
+    fun increase(): ScrapCount = ScrapCount(value + 1)
+
+    fun decrease(): ScrapCount {
+        require(value > MIN_VALUE) { CANNOT_DECREASE_BELOW_ZERO_MESSAGE }
+        return ScrapCount(value - 1)
+    }
+
+    companion object {
+        private const val MIN_VALUE = 0
+        private const val INVALID_SCRAP_COUNT_MESSAGE = "스크랩 수는 음수일 수 없습니다."
+        private const val CANNOT_DECREASE_BELOW_ZERO_MESSAGE = "스크랩 수는 0보다 작아질 수 없습니다."
+
+        fun from(): ScrapCount = ScrapCount(MIN_VALUE)
+    }
+
+    override fun equals(other: Any?): Boolean = other is ScrapCount && value == other.value
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = value.toString()
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/ScrapCount.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/ScrapCount.kt
@@ -6,6 +6,8 @@ import jakarta.persistence.Embeddable
 class ScrapCount private constructor(
     val value: Int,
 ) {
+    protected constructor() : this(MIN_VALUE)
+
     init {
         require(value >= MIN_VALUE) { INVALID_SCRAP_COUNT_MESSAGE }
     }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/ViewCount.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/ViewCount.kt
@@ -12,16 +12,16 @@ class ViewCount private constructor(
 
     fun increase(): ViewCount = ViewCount(value + 1)
 
+    override fun equals(other: Any?): Boolean = other is ViewCount && value == other.value
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = value.toString()
+
     companion object {
         private const val MIN_VALUE = 0
         private const val INVALID_VIEW_COUNT_MESSAGE = "조회수는 음수일 수 없습니다."
 
         fun from(): ViewCount = ViewCount(MIN_VALUE)
     }
-
-    override fun equals(other: Any?): Boolean = other is ViewCount && value == other.value
-
-    override fun hashCode(): Int = value.hashCode()
-
-    override fun toString(): String = value.toString()
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.terning.server.kotlin.domain.auth.AuthException
 import com.terning.server.kotlin.domain.common.BaseException
+import com.terning.server.kotlin.domain.auth.AuthException
+import com.terning.server.kotlin.domain.user.UserException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ExceptionHandler.kt
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.terning.server.kotlin.domain.auth.AuthException
 import com.terning.server.kotlin.domain.common.BaseException
-import com.terning.server.kotlin.domain.auth.AuthException
-import com.terning.server.kotlin.domain.user.UserException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/DeadlineTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/DeadlineTest.kt
@@ -9,68 +9,43 @@ class DeadlineTest {
     @Test
     @DisplayName("마감일이 오늘보다 이전이면 isOver는 true를 반환한다")
     fun `deadline before today returns true`() {
-        // given
-        val yesterday = LocalDate.now().minusDays(1)
-        val deadline = Deadline.from(yesterday)
-
-        // when
-        val result = deadline.isOver()
-
-        // then
+        val deadline = Deadline.from(LocalDate.now())
+        val result = deadline.isOver(LocalDate.now().plusDays(1))
         assertThat(result).isTrue
     }
 
     @Test
     @DisplayName("마감일이 오늘이면 isOver는 false를 반환한다")
     fun `deadline equals today returns false`() {
-        // given
         val today = LocalDate.now()
-        val deadline = Deadline.from(today)
-
-        // when
-        val result = deadline.isOver()
-
-        // then
+        val deadline = Deadline.from(today.plusDays(1))
+        val result = deadline.isOver(today.plusDays(1))
         assertThat(result).isFalse
     }
 
     @Test
     @DisplayName("마감일이 오늘보다 이후면 isOver는 false를 반환한다")
     fun `deadline after today returns false`() {
-        // given
-        val tomorrow = LocalDate.now().plusDays(1)
-        val deadline = Deadline.from(tomorrow)
-
-        // when
+        val deadline = Deadline.from(LocalDate.now().plusDays(2))
         val result = deadline.isOver()
-
-        // then
         assertThat(result).isFalse
     }
 
-    @DisplayName("마감일이 2025년 1월 2일보다 이전이면 예외가 발생한다")
-    fun `deadline before 2025-01-02 throws exception`() {
-        // given
-        val invalid = LocalDate.of(2025, 1, 1)
-
-        // when
+    @Test
+    @DisplayName("마감일이 2024년 1월 1일보다 이전이면 예외가 발생한다")
+    fun `deadline before 2024-01-02 throws exception`() {
+        val invalid = LocalDate.of(2024, 1, 1)
         val result = runCatching { Deadline.from(invalid) }
-
-        // then
         assertThat(result.exceptionOrNull())
             .isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessage("마감일은 2025년 이후여야 합니다.")
+            .hasMessage("마감일은 2024-01-01 이후여야 합니다.")
     }
 
-    @DisplayName("마감일이 2025년 1월 2일이면 생성된다")
-    fun `deadline after 2025-01-01 is valid`() {
-        // given
-        val valid = LocalDate.of(2025, 1, 2)
-
-        // when
+    @Test
+    @DisplayName("마감일이 2024년 1월 2일이면 생성된다")
+    fun `deadline after 2024-01-01 is valid`() {
+        val valid = LocalDate.of(2024, 1, 2)
         val result = Deadline.from(valid)
-
-        // then
         assertThat(result.value).isEqualTo(valid)
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/ScrapCountTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/ScrapCountTest.kt
@@ -1,0 +1,59 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ScrapCountTest {
+    @Test
+    @DisplayName("from()을 호출하면 값이 0인 ScrapCount가 생성된다")
+    fun `initial scrap count is zero`() {
+        // when
+        val scrapCount = ScrapCount.from()
+
+        // then
+        assertThat(scrapCount.value).isZero()
+    }
+
+    @Test
+    @DisplayName("increase()를 호출하면 값이 1 증가된 ScrapCount가 반환된다")
+    fun `increase returns new instance with incremented value`() {
+        // given
+        val scrapCount = ScrapCount.from()
+
+        // when
+        val increased = scrapCount.increase()
+
+        // then
+        assertThat(increased.value).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("decrease()를 호출하면 값이 1 감소된 ScrapCount가 반환된다")
+    fun `decrease returns new instance with decremented value`() {
+        // given
+        val scrapCount = ScrapCount.from().increase()
+
+        // when
+        val decreased = scrapCount.decrease()
+
+        // then
+        assertThat(decreased.value).isEqualTo(0)
+    }
+
+    @Test
+    @DisplayName("값이 0일 때 decrease()를 호출하면 예외가 발생한다")
+    fun `decrease throws exception when value is zero`() {
+        // given
+        val scrapCount = ScrapCount.from()
+
+        // when & then
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                scrapCount.decrease()
+            }
+
+        assertThat(exception.message).isEqualTo("스크랩 수는 0보다 작아질 수 없습니다.")
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
`InternshipAnnouncement`의 스크랩 수를 관리하기 위한 값 객체 `ScrapCount`를 구현했습니다.  
정수 기반의 단순 필드를 VO로 추출하여 불변성과 도메인 책임을 명확히 했습니다.

- `from()`을 통해 항상 0으로 초기화되며 외부 값 주입은 허용하지 않습니다.
- `increase()`와 `decrease()`를 통해 상태를 변경하며, 감소 시 0 이하로 내려갈 수 없도록 보호합니다.
- equals, hashCode, toString을 오버라이딩하여 VO 특성을 갖추었습니다.

---

# 💭 Thoughts  
- 조회수와 달리 스크랩 수는 증가와 감소가 모두 필요한 값이므로 decrease() 메서드를 추가했습니다.
- 음수로 감소하지 않도록 방어 로직을 포함하여 도메인 무결성을 보장합니다.
- 이후 `InternshipAnnouncement` 엔티티에 적용하여 책임 분리 및 테스트 가능성을 높일 예정입니다.

---

# ✅ Testing Result  
![스크린샷 2025-05-18 오후 3 19 53](https://github.com/user-attachments/assets/b9391f98-1acf-48d3-8687-8c0e545916f2)


---

# 🗂 Related Issue  
- closed #46 
