### PR TITLE
[✨feat] CompanyCategory 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyCategory.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyCategory.kt
@@ -1,21 +1,20 @@
 package com.terning.server.kotlin.domain.internshipAnnouncement
 
 enum class CompanyCategory(
-    val categoryId: Int,
-    val description: String,
+    val displayName: String,
 ) {
-    LARGE_AND_MEDIUM_COMPANIES(0, "대기업/중견기업"),
-    SMALL_COMPANIES(1, "중소기업"),
-    PUBLIC_INSTITUTIONS(2, "공공기관/공기업"),
-    FOREIGN_COMPANIES(3, "외국계기업"),
-    STARTUPS(4, "스타트업"),
-    NON_PROFIT_ORGANIZATIONS(5, "비영리단체/재단"),
-    OTHERS(6, "기타"),
+    LARGE_AND_MEDIUM_COMPANIES("대기업/중견기업"),
+    SMALL_COMPANIES("중소기업"),
+    PUBLIC_INSTITUTIONS("공공기관/공기업"),
+    FOREIGN_COMPANIES("외국계기업"),
+    STARTUPS("스타트업"),
+    NON_PROFIT_ORGANIZATIONS("비영리단체/재단"),
+    OTHERS("기타"),
     ;
 
     companion object {
-        fun from(value: Int): CompanyCategory =
-            entries.firstOrNull { it.categoryId == value }
+        fun from(displayName: String): CompanyCategory =
+            entries.firstOrNull { it.displayName == displayName }
                 ?: throw InternshipException(InternshipErrorCode.INVALID_COMPANY_CATEGORY)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyCategory.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyCategory.kt
@@ -1,0 +1,21 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+enum class CompanyCategory(
+    val categoryId: Int,
+    val description: String,
+) {
+    LARGE_AND_MEDIUM_COMPANIES(0, "대기업/중견기업"),
+    SMALL_COMPANIES(1, "중소기업"),
+    PUBLIC_INSTITUTIONS(2, "공공기관/공기업"),
+    FOREIGN_COMPANIES(3, "외국계기업"),
+    STARTUPS(4, "스타트업"),
+    NON_PROFIT_ORGANIZATIONS(5, "비영리단체/재단"),
+    OTHERS(6, "기타"),
+    ;
+
+    companion object {
+        fun from(value: Int): CompanyCategory =
+            entries.firstOrNull { it.categoryId == value }
+                ?: throw InternshipException(InternshipErrorCode.INVALID_COMPANY_CATEGORY)
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -11,5 +11,5 @@ enum class InternshipErrorCode(
     INVALID_SCRAP_COUNT(HttpStatus.BAD_REQUEST, "스크랩 수는 음수일 수 없습니다."),
     SCRAP_COUNT_CANNOT_BE_DECREASED_BELOW_ZERO(HttpStatus.BAD_REQUEST, "스크랩 수는 0보다 작아질 수 없습니다."),
     INVALID_VIEW_COUNT(HttpStatus.BAD_REQUEST, "조회수는 음수일 수 없습니다."),
-    INVALID_COMPANY_CATEGORY(HttpStatus.BAD_REQUEST, "올바르지 않은 기업 구분 값입니다."),
+    INVALID_COMPANY_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 기업 유형입니다.")
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -11,4 +11,5 @@ enum class InternshipErrorCode(
     INVALID_SCRAP_COUNT(HttpStatus.BAD_REQUEST, "스크랩 수는 음수일 수 없습니다."),
     SCRAP_COUNT_CANNOT_BE_DECREASED_BELOW_ZERO(HttpStatus.BAD_REQUEST, "스크랩 수는 0보다 작아질 수 없습니다."),
     INVALID_VIEW_COUNT(HttpStatus.BAD_REQUEST, "조회수는 음수일 수 없습니다."),
+    INVALID_COMPANY_CATEGORY(HttpStatus.BAD_REQUEST, "올바르지 않은 기업 구분 값입니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -11,5 +11,5 @@ enum class InternshipErrorCode(
     INVALID_SCRAP_COUNT(HttpStatus.BAD_REQUEST, "스크랩 수는 음수일 수 없습니다."),
     SCRAP_COUNT_CANNOT_BE_DECREASED_BELOW_ZERO(HttpStatus.BAD_REQUEST, "스크랩 수는 0보다 작아질 수 없습니다."),
     INVALID_VIEW_COUNT(HttpStatus.BAD_REQUEST, "조회수는 음수일 수 없습니다."),
-    INVALID_COMPANY_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 기업 유형입니다.")
+    INVALID_COMPANY_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 기업 유형입니다."),
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyCategoryTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyCategoryTest.kt
@@ -1,0 +1,43 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class CompanyCategoryTest {
+    @DisplayName("유효한 categoryId를 전달하면 해당 CompanyCategory를 반환한다")
+    @ParameterizedTest(name = "categoryId {0} -> {1}")
+    @CsvSource(
+        "0, LARGE_AND_MEDIUM_COMPANIES",
+        "1, SMALL_COMPANIES",
+        "2, PUBLIC_INSTITUTIONS",
+        "3, FOREIGN_COMPANIES",
+        "4, STARTUPS",
+        "5, NON_PROFIT_ORGANIZATIONS",
+        "6, OTHERS",
+    )
+    fun `return correct CompanyCategory for valid categoryId`(
+        categoryId: Int,
+        expectedEnumName: String,
+    ) {
+        // when
+        val result = CompanyCategory.from(categoryId)
+        // then
+        assertThat(result.name).isEqualTo(expectedEnumName)
+    }
+
+    @DisplayName("유효하지 않은 categoryId를 전달하면 InternshipException을 던진다")
+    @ParameterizedTest(name = "categoryId {0} -> exception")
+    @ValueSource(ints = [-1, 7, 100, 999])
+    fun `throw exception when categoryId is invalid`(invalidCategoryId: Int) {
+        // when & then
+        val exception =
+            assertThrows<InternshipException> {
+                CompanyCategory.from(invalidCategoryId)
+            }
+        assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_COMPANY_CATEGORY)
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyCategoryTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyCategoryTest.kt
@@ -8,35 +8,32 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class CompanyCategoryTest {
-    @DisplayName("유효한 categoryId를 전달하면 해당 CompanyCategory를 반환한다")
-    @ParameterizedTest(name = "categoryId {0} -> {1}")
+    @DisplayName("displayName으로 CompanyCategory를 조회할 수 있다")
+    @ParameterizedTest(name = "displayName: {0} -> {1}")
     @CsvSource(
-        "0, LARGE_AND_MEDIUM_COMPANIES",
-        "1, SMALL_COMPANIES",
-        "2, PUBLIC_INSTITUTIONS",
-        "3, FOREIGN_COMPANIES",
-        "4, STARTUPS",
-        "5, NON_PROFIT_ORGANIZATIONS",
-        "6, OTHERS",
+        "대기업/중견기업, LARGE_AND_MEDIUM_COMPANIES",
+        "중소기업, SMALL_COMPANIES",
+        "공공기관/공기업, PUBLIC_INSTITUTIONS",
+        "외국계기업, FOREIGN_COMPANIES",
+        "스타트업, STARTUPS",
+        "비영리단체/재단, NON_PROFIT_ORGANIZATIONS",
+        "기타, OTHERS",
     )
-    fun `return correct CompanyCategory for valid categoryId`(
-        categoryId: Int,
+    fun `return correct CompanyCategory for valid displayName`(
+        displayName: String,
         expectedEnumName: String,
     ) {
-        // when
-        val result = CompanyCategory.from(categoryId)
-        // then
+        val result = CompanyCategory.from(displayName)
         assertThat(result.name).isEqualTo(expectedEnumName)
     }
 
-    @DisplayName("유효하지 않은 categoryId를 전달하면 InternshipException을 던진다")
-    @ParameterizedTest(name = "categoryId {0} -> exception")
-    @ValueSource(ints = [-1, 7, 100, 999])
-    fun `throw exception when categoryId is invalid`(invalidCategoryId: Int) {
-        // when & then
+    @DisplayName("존재하지 않는 displayName을 전달하면 예외가 발생한다")
+    @ParameterizedTest(name = "invalid displayName: {0}")
+    @ValueSource(strings = ["", "대기업", "터닝", "UNKNOWN", "스타트업스"])
+    fun `throw exception when displayName is invalid`(invalidName: String) {
         val exception =
             assertThrows<InternshipException> {
-                CompanyCategory.from(invalidCategoryId)
+                CompanyCategory.from(invalidName)
             }
         assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_COMPANY_CATEGORY)
     }


### PR DESCRIPTION
# 📄 Work Description  
- Internship 도메인에서 기업 유형을 나타내는 `CompanyCategory` Enum을 정의했습니다.  
- 각 항목은 `categoryId`와 `description`을 갖고, 정적 팩터리 메서드 `from(Int)`를 통해 매핑됩니다.  
- 유효하지 않은 값에 대해 `InternshipException`과 `INVALID_COMPANY_CATEGORY`를 활용한 예외 처리를 적용했습니다.  
- 예외 코드는 `InternshipErrorCode`에 항목을 추가해 관리합니다.  

# 💭 Thoughts  
- 기존 자바 Enum에서 코틀린 Enum으로 이관하면서, 도메인에 맞는 의미 있는 필드명(`categoryId`, `description`)으로 개선했습니다.  
- 매핑 메서드는 하나의 `from(Int)`로 통일하고, 문자열 기반 매핑은 제거하여 책임을 명확히 했습니다.  
- 테스트는 파라미터 기반으로 구성해 가독성과 커버리지를 동시에 확보했습니다.  

- 다만 현재는 레거시 시스템과의 호환을 위해 `0`, `1`, `2`처럼 숫자 기반의 식별자를 클라이언트에서 그대로 받고 있습니다.  
  이 구조는 잠깐 보기엔 단순하고 편해 보일 수 있지만, 실제로는 꽤 위험한 방식이에요.  
  예를 들어, `0 = 대기업`, `1 = 중소기업`으로 의미가 정해져 있다가 새로운 항목이 추가되거나 순서를 바꾸게 되면  
  클라이언트와 서버 모두에서 큰 혼란이 생길 수 있어요.  
  숫자 값은 그 자체로는 아무 의미도 없기 때문에, 나중에 코드를 보는 사람에게도 의도를 전달하기 어렵고요.

- 처음 자바 + 스프링 기반으로 프로젝트를 시작할 때도 이런 숫자 기반 매핑보다는  
  **명확한 이름이나 문자열 값(description 등)을 기반으로 통신하자고 강조했던 기억이 납니다.**  
  지금은 마이그레이션 과정이라 기존 구조를 따르되,  
  **앞으로는 클라이언트와의 통신에서도 의미 있는 값을 주고받는 방향으로 리팩터링하는 것이 더 안전하고 유지보수에 유리하다고 다시 한번 강조하고 싶어요. 🙏**


# ✅ Testing Result  
![스크린샷 2025-05-18 오후 7 31 04](https://github.com/user-attachments/assets/07623d7d-aff1-471e-8d8a-54fb23f4a124)

# 🗂 Related Issue  
- closed #50
