### PR TITLE
[✨feat] CompanyName 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyName.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyName.kt
@@ -1,0 +1,34 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+class CompanyName private constructor(
+    val value: String,
+) {
+    init {
+        validateNotBlank(value)
+        validateMaxLength(value)
+    }
+
+    companion object {
+        private const val MAX_LENGTH = 64
+
+        fun from(value: String): CompanyName = CompanyName(value)
+
+        private fun validateNotBlank(value: String) {
+            if (value.isBlank()) {
+                throw InternshipException(InternshipErrorCode.INVALID_COMPANY_NAME_EMPTY)
+            }
+        }
+
+        private fun validateMaxLength(value: String) {
+            if (value.length > MAX_LENGTH) {
+                throw InternshipException(InternshipErrorCode.INVALID_COMPANY_NAME_TOO_LONG)
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = this === other || (other is CompanyName && value == other.value)
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -12,4 +12,6 @@ enum class InternshipErrorCode(
     SCRAP_COUNT_CANNOT_BE_DECREASED_BELOW_ZERO(HttpStatus.BAD_REQUEST, "스크랩 수는 0보다 작아질 수 없습니다."),
     INVALID_VIEW_COUNT(HttpStatus.BAD_REQUEST, "조회수는 음수일 수 없습니다."),
     INVALID_COMPANY_CATEGORY(HttpStatus.BAD_REQUEST, "올바르지 않은 기업 구분 값입니다."),
+    INVALID_COMPANY_NAME_EMPTY(HttpStatus.BAD_REQUEST, "기업명은 비어 있을 수 없습니다."),
+    INVALID_COMPANY_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "기업명은 64자 이하여야 합니다."),
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyNameTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyNameTest.kt
@@ -1,0 +1,56 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CompanyNameTest {
+    @Nested
+    @DisplayName("CompanyName.from 메서드는")
+    inner class From {
+        @Test
+        @DisplayName("유효한 값이면 CompanyName을 생성한다")
+        fun `create CompanyName when valid`() {
+            // given
+            val value = "구글"
+
+            // when
+            val result = CompanyName.from(value)
+
+            // then
+            assertThat(result.value).isEqualTo(value)
+        }
+
+        @Test
+        @DisplayName("비어 있거나 공백뿐인 값이면 예외를 던진다")
+        fun `throw exception when name is blank`() {
+            // given
+            val blank = "    "
+
+            // when & then
+            val exception =
+                assertThrows<InternshipException> {
+                    CompanyName.from(blank)
+                }
+
+            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_COMPANY_NAME_EMPTY)
+        }
+
+        @Test
+        @DisplayName("64자를 초과하는 값이면 예외를 던진다")
+        fun `throw exception when name is too long`() {
+            // given
+            val tooLong = "A".repeat(65)
+
+            // when & then
+            val exception =
+                assertThrows<InternshipException> {
+                    CompanyName.from(tooLong)
+                }
+
+            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_COMPANY_NAME_TOO_LONG)
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- 기업명을 값 객체로 다루기 위한 `CompanyName` VO를 구현했습니다.  
- 내부에 문자열 필드 `value`를 가지고 있으며, 생성 시 유효성 검증을 수행합니다.  
- 정적 팩터리 메서드 `from()`을 통해 생성하도록 제한하였습니다.  
- VO 특성에 맞게 `equals`, `hashCode`, `toString`을 오버라이드했습니다.  

# 💭 Thoughts  
- 단순 문자열로 기업명을 다루기보다 VO로 분리하여 **도메인 의미를 명확히 드러내고**,  
  **유효성 검증 책임을 한 곳에 집중**하도록 설계했습니다.  
- 현재는 두 가지 규칙(공백 불가, 64자 제한)을 검증하고 있으며,  
  각 검증을 `init` 블록에서 직접 호출하여 **의도를 더 잘 드러내는 방식**으로 구성했습니다.  
- 예외는 `InternshipException`을 통해 처리하고, `InternshipErrorCode` 항목을 별도로 정의해  
  **도메인 일관성**과 **API 응답 처리의 명확성**을 함께 고려했습니다.  

# ✅ Testing Result  

![스크린샷 2025-05-18 오후 7 47 15](https://github.com/user-attachments/assets/3f639fa6-d2e2-415e-ac6f-0277414a782a)

# 🗂 Related Issue  
- closed #52
