### PR TITLE
[✨feat] InternshipTitle 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -14,4 +14,6 @@ enum class InternshipErrorCode(
     INVALID_COMPANY_CATEGORY(HttpStatus.BAD_REQUEST, "올바르지 않은 기업 구분 값입니다."),
     INVALID_COMPANY_NAME_EMPTY(HttpStatus.BAD_REQUEST, "기업명은 비어 있을 수 없습니다."),
     INVALID_COMPANY_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "기업명은 64자 이하여야 합니다."),
+    INVALID_INTERNSHIP_TITLE_EMPTY(HttpStatus.BAD_REQUEST, "인턴십 제목은 비어 있을 수 없습니다."),
+    INVALID_INTERNSHIP_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "인턴십 제목은 64자 이하여야 합니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipTitle.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipTitle.kt
@@ -1,0 +1,39 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class InternshipTitle private constructor(
+    val value: String,
+) {
+    init {
+        validateNotBlank(value)
+        validateMaxLength(value)
+    }
+
+    companion object {
+        private const val MAX_LENGTH = 64
+
+        fun from(value: String): InternshipTitle {
+            return InternshipTitle(value)
+        }
+
+        private fun validateNotBlank(value: String) {
+            if (value.isBlank()) {
+                throw InternshipException(InternshipErrorCode.INVALID_INTERNSHIP_TITLE_EMPTY)
+            }
+        }
+
+        private fun validateMaxLength(value: String) {
+            if (value.length > MAX_LENGTH) {
+                throw InternshipException(InternshipErrorCode.INVALID_INTERNSHIP_TITLE_TOO_LONG)
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = this === other || (other is InternshipTitle && value == other.value)
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = value
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipTitleTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipTitleTest.kt
@@ -1,0 +1,56 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class InternshipTitleTest {
+    @Nested
+    @DisplayName("InternshipTitle.from 메서드는")
+    inner class From {
+        @Test
+        @DisplayName("유효한 값이면 InternshipTitle을 생성한다")
+        fun `create InternshipTitle when valid`() {
+            // given
+            val value = "백엔드 인턴십"
+
+            // when
+            val result = InternshipTitle.from(value)
+
+            // then
+            assertThat(result.value).isEqualTo(value)
+        }
+
+        @Test
+        @DisplayName("비어 있거나 공백뿐인 값이면 예외를 던진다")
+        fun `throw exception when title is blank`() {
+            // given
+            val blank = "    "
+
+            // when & then
+            val exception =
+                assertThrows<InternshipException> {
+                    InternshipTitle.from(blank)
+                }
+
+            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_INTERNSHIP_TITLE_EMPTY)
+        }
+
+        @Test
+        @DisplayName("64자를 초과하는 값이면 예외를 던진다")
+        fun `throw exception when title is too long`() {
+            // given
+            val tooLong = "인턴십".repeat(22)
+
+            // when & then
+            val exception =
+                assertThrows<InternshipException> {
+                    InternshipTitle.from(tooLong)
+                }
+
+            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_INTERNSHIP_TITLE_TOO_LONG)
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- 인턴십 공고 제목을 도메인 객체로 표현하기 위해 `InternshipTitle` VO(Value Object)를 구현했습니다.  
- 유효성 검증을 통해 비어 있는 값이나 64자를 초과하는 제목에 대해 예외를 발생시키도록 설계했습니다.  
- 예외 처리는 `InternshipException`과 `InternshipErrorCode`를 활용하여 명확하게 구분했습니다.  
- `@Embeddable` 어노테이션을 활용해 JPA 내장 타입으로 매핑되며, DB와의 연동을 고려한 설계입니다.  

---

# 💭 Thoughts  
- 인턴십 제목은 단순한 String이지만, 도메인 개념상 의미가 분명하다고 판단되어 VO로 분리했습니다.  
- 특히 공백만 있는 문자열도 유효하지 않도록 `isBlank()`를 사용해 체크했습니다.  
- 입력값에서 `trim()` 처리를 하지 않은 이유는, 제목에 양끝 공백이 의도적으로 포함될 가능성도 고려했기 때문입니다.  
- VO 내에서 출력 포맷이나 가공은 하지 않고 순수하게 상태만 표현하도록 설계했습니다.  

---

# ✅ Testing Result  
![스크린샷 2025-05-19 오후 10 46 36](https://github.com/user-attachments/assets/0771395c-d1f0-4e69-9e23-bb92a88fce10)


---

# 🗂 Related Issue  
- closed #54
