### PR TITLE
[✨feat] InternshipWorkingPeriod 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -16,4 +16,5 @@ enum class InternshipErrorCode(
     INVALID_COMPANY_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "기업명은 64자 이하여야 합니다."),
     INVALID_INTERNSHIP_TITLE_EMPTY(HttpStatus.BAD_REQUEST, "인턴십 제목은 비어 있을 수 없습니다."),
     INVALID_INTERNSHIP_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "인턴십 제목은 64자 이하여야 합니다."),
+    INVALID_WORKING_PERIOD(HttpStatus.BAD_REQUEST, "근무 기간은 1개월 이상이어야 합니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriod.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriod.kt
@@ -1,0 +1,32 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class InternshipWorkingPeriod private constructor(
+    val months: Int,
+) {
+    init {
+        validatePositive(months)
+    }
+
+    companion object {
+        fun from(months: Int): InternshipWorkingPeriod {
+            return InternshipWorkingPeriod(months)
+        }
+
+        private fun validatePositive(months: Int) {
+            if (months <= 0) {
+                throw InternshipException(InternshipErrorCode.INVALID_WORKING_PERIOD)
+            }
+        }
+    }
+
+    fun toKoreanPeriod(): String = "${months}개월"
+
+    override fun equals(other: Any?): Boolean = this === other || (other is InternshipWorkingPeriod && months == other.months)
+
+    override fun hashCode(): Int = months
+
+    override fun toString(): String = toKoreanPeriod()
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriod.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriod.kt
@@ -12,17 +12,20 @@ class InternshipWorkingPeriod private constructor(
 
     fun toKoreanPeriod(): String = "${months}개월"
 
-    override fun equals(other: Any?): Boolean = this === other || (other is InternshipWorkingPeriod && months == other.months)
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is InternshipWorkingPeriod && months == other.months)
 
     override fun hashCode(): Int = months
 
     override fun toString(): String = toKoreanPeriod()
 
     companion object {
+        private const val MINIMUM_MONTHS = 1
+
         fun from(months: Int): InternshipWorkingPeriod = InternshipWorkingPeriod(months)
 
         private fun validatePositive(months: Int) {
-            if (months <= 0) {
+            if (months < MINIMUM_MONTHS) {
                 throw InternshipException(InternshipErrorCode.INVALID_WORKING_PERIOD)
             }
         }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriod.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriod.kt
@@ -10,18 +10,6 @@ class InternshipWorkingPeriod private constructor(
         validatePositive(months)
     }
 
-    companion object {
-        fun from(months: Int): InternshipWorkingPeriod {
-            return InternshipWorkingPeriod(months)
-        }
-
-        private fun validatePositive(months: Int) {
-            if (months <= 0) {
-                throw InternshipException(InternshipErrorCode.INVALID_WORKING_PERIOD)
-            }
-        }
-    }
-
     fun toKoreanPeriod(): String = "${months}개월"
 
     override fun equals(other: Any?): Boolean = this === other || (other is InternshipWorkingPeriod && months == other.months)
@@ -29,4 +17,14 @@ class InternshipWorkingPeriod private constructor(
     override fun hashCode(): Int = months
 
     override fun toString(): String = toKoreanPeriod()
+
+    companion object {
+        fun from(months: Int): InternshipWorkingPeriod = InternshipWorkingPeriod(months)
+
+        private fun validatePositive(months: Int) {
+            if (months <= 0) {
+                throw InternshipException(InternshipErrorCode.INVALID_WORKING_PERIOD)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriod.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriod.kt
@@ -12,8 +12,7 @@ class InternshipWorkingPeriod private constructor(
 
     fun toKoreanPeriod(): String = "${months}개월"
 
-    override fun equals(other: Any?): Boolean =
-        this === other || (other is InternshipWorkingPeriod && months == other.months)
+    override fun equals(other: Any?): Boolean = this === other || (other is InternshipWorkingPeriod && months == other.months)
 
     override fun hashCode(): Int = months
 

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriodTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipWorkingPeriodTest.kt
@@ -1,0 +1,54 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class InternshipWorkingPeriodTest {
+    @Nested
+    @DisplayName("InternshipWorkingPeriod.from 메서드는")
+    inner class From {
+        @Test
+        @DisplayName("유효한 개월 수를 입력하면 객체를 생성한다")
+        fun `create instance when valid months given`() {
+            // given
+            val months = 3
+
+            // when
+            val period = InternshipWorkingPeriod.from(months)
+
+            // then
+            assertThat(period.months).isEqualTo(months)
+        }
+
+        @Test
+        @DisplayName("0 이하의 개월 수를 입력하면 예외를 던진다")
+        fun `throw exception when months is zero or negative`() {
+            val exception =
+                assertThrows<InternshipException> {
+                    InternshipWorkingPeriod.from(0)
+                }
+
+            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_WORKING_PERIOD)
+        }
+    }
+
+    @Nested
+    @DisplayName("toKoreanPeriod 메서드는")
+    inner class ToKoreanPeriod {
+        @Test
+        @DisplayName("개월 수를 'N개월' 형태의 문자열로 반환한다")
+        fun `return correct korean period string`() {
+            // given
+            val period = InternshipWorkingPeriod.from(6)
+
+            // when
+            val result = period.toKoreanPeriod()
+
+            // then
+            assertThat(result).isEqualTo("6개월")
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- 인턴십 공고의 근무 기간을 표현하는 VO `InternshipWorkingPeriod`를 구현했습니다.  
- 유효성 검증을 통해 0 이하의 개월 수 입력 시 `InternshipException`을 발생시키도록 했습니다.  
- 기간 정보를 사용자에게 보여주기 위해 `toKoreanPeriod` 메서드를 제공하여 "N개월" 형식으로 반환합니다.  
- 예외 처리를 위해 `InternshipErrorCode.INVALID_WORKING_PERIOD` 항목을 새롭게 정의했습니다.  

---

# 💭 Thoughts  
- 단순히 개월 수를 Int로 관리하면 유효하지 않은 값이 혼입될 가능성이 있어 VO로 추상화했습니다.  
- `equals`, `hashCode`, `toString`을 오버라이드하여 VO 특성을 보장하며, 출력 포맷은 명확히 분리된 메서드로 관리했습니다.  
- 앞으로 기간과 관련된 도메인 규칙(예: 최대 개월 수 제한 등)이 생기더라도 이 VO를 중심으로 확장할 수 있는 구조입니다.  

---

# ✅ Testing Result  
![스크린샷 2025-05-19 오후 11 28 37](https://github.com/user-attachments/assets/d0f37904-0062-48ad-b5c6-ddaa7ba3bd0e)

---

# 🗂 Related Issue  
- closed #56
