### PR TITLE
[✨feat] CompanyImageUrl VO 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrl.kt
@@ -8,13 +8,11 @@ import java.net.URISyntaxException
 class CompanyLogoUrl private constructor(
     val value: String,
 ) {
-
     init {
         validateUrl(value)
     }
 
-    override fun equals(other: Any?): Boolean =
-        this === other || (other is CompanyLogoUrl && value == other.value)
+    override fun equals(other: Any?): Boolean = this === other || (other is CompanyLogoUrl && value == other.value)
 
     override fun hashCode(): Int = value.hashCode()
 

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrl.kt
@@ -1,28 +1,40 @@
 package com.terning.server.kotlin.domain.internshipAnnouncement
 
 import jakarta.persistence.Embeddable
+import java.net.URI
+import java.net.URISyntaxException
 
 @Embeddable
 class CompanyLogoUrl private constructor(
     val value: String,
 ) {
+
     init {
         validateUrl(value)
     }
 
-    companion object {
-        fun from(value: String): CompanyLogoUrl = CompanyLogoUrl(value)
-
-        private fun validateUrl(value: String) {
-            if (!value.startsWith("http")) {
-                throw InternshipException(InternshipErrorCode.INVALID_COMPANY_LOGO_URL)
-            }
-        }
-    }
-
-    override fun equals(other: Any?): Boolean = this === other || (other is CompanyLogoUrl && value == other.value)
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is CompanyLogoUrl && value == other.value)
 
     override fun hashCode(): Int = value.hashCode()
 
     override fun toString(): String = value
+
+    companion object {
+        private val ALLOWED_SCHEMES = setOf("http", "https")
+
+        fun from(value: String): CompanyLogoUrl = CompanyLogoUrl(value)
+
+        private fun validateUrl(value: String) {
+            try {
+                val uri = URI(value)
+                val scheme = uri.scheme?.lowercase()
+                if (scheme !in ALLOWED_SCHEMES) {
+                    throw InternshipException(InternshipErrorCode.UNSUPPORTED_COMPANY_LOGO_URL_SCHEME)
+                }
+            } catch (e: URISyntaxException) {
+                throw InternshipException(InternshipErrorCode.INVALID_COMPANY_LOGO_URL_FORMAT)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrl.kt
@@ -1,0 +1,28 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class CompanyLogoUrl private constructor(
+    val value: String,
+) {
+    init {
+        validateUrl(value)
+    }
+
+    companion object {
+        fun from(value: String): CompanyLogoUrl = CompanyLogoUrl(value)
+
+        private fun validateUrl(value: String) {
+            if (!value.startsWith("http")) {
+                throw InternshipException(InternshipErrorCode.INVALID_COMPANY_LOGO_URL)
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = this === other || (other is CompanyLogoUrl && value == other.value)
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -19,5 +19,6 @@ enum class InternshipErrorCode(
     INVALID_WORKING_PERIOD(HttpStatus.BAD_REQUEST, "근무 기간은 1개월 이상이어야 합니다."),
     INVALID_MONTH(HttpStatus.BAD_REQUEST, "월은 1~12 사이여야 합니다."),
     INVALID_YEAR(HttpStatus.BAD_REQUEST, "연도는 2025보다 커야 합니다."),
-    INVALID_COMPANY_LOGO_URL(HttpStatus.BAD_REQUEST, "올바른 이미지 URL이 아닙니다."),
+    INVALID_COMPANY_LOGO_URL_FORMAT(HttpStatus.BAD_REQUEST, "회사 로고 URL 형식이 잘못되었습니다."),
+    UNSUPPORTED_COMPANY_LOGO_URL_SCHEME(HttpStatus.BAD_REQUEST, "지원하지 않는 URL scheme입니다. http 또는 https만 허용됩니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -19,4 +19,5 @@ enum class InternshipErrorCode(
     INVALID_WORKING_PERIOD(HttpStatus.BAD_REQUEST, "근무 기간은 1개월 이상이어야 합니다."),
     INVALID_MONTH(HttpStatus.BAD_REQUEST, "월은 1~12 사이여야 합니다."),
     INVALID_YEAR(HttpStatus.BAD_REQUEST, "연도는 2025보다 커야 합니다."),
+    INVALID_COMPANY_LOGO_URL(HttpStatus.BAD_REQUEST, "올바른 이미지 URL이 아닙니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -7,7 +7,7 @@ enum class InternshipErrorCode(
     override val status: HttpStatus,
     override val message: String,
 ) : BaseErrorCode {
-    INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "마감일은 2025년 이후여야 합니다."),
+    INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "마감일은 2024년 이후여야 합니다."),
     INVALID_SCRAP_COUNT(HttpStatus.BAD_REQUEST, "스크랩 수는 음수일 수 없습니다."),
     SCRAP_COUNT_CANNOT_BE_DECREASED_BELOW_ZERO(HttpStatus.BAD_REQUEST, "스크랩 수는 0보다 작아질 수 없습니다."),
     INVALID_VIEW_COUNT(HttpStatus.BAD_REQUEST, "조회수는 음수일 수 없습니다."),
@@ -18,7 +18,7 @@ enum class InternshipErrorCode(
     INVALID_INTERNSHIP_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "인턴십 제목은 64자 이하여야 합니다."),
     INVALID_WORKING_PERIOD(HttpStatus.BAD_REQUEST, "근무 기간은 1개월 이상이어야 합니다."),
     INVALID_MONTH(HttpStatus.BAD_REQUEST, "월은 1~12 사이여야 합니다."),
-    INVALID_YEAR(HttpStatus.BAD_REQUEST, "연도는 2025보다 커야 합니다."),
+    INVALID_YEAR(HttpStatus.BAD_REQUEST, "연도는 2024보다 커야 합니다."),
     INVALID_COMPANY_LOGO_URL_FORMAT(HttpStatus.BAD_REQUEST, "회사 로고 URL 형식이 잘못되었습니다."),
     UNSUPPORTED_COMPANY_LOGO_URL_SCHEME(HttpStatus.BAD_REQUEST, "지원하지 않는 URL scheme입니다. http 또는 https만 허용됩니다."),
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrlTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrlTest.kt
@@ -11,7 +11,7 @@ class CompanyLogoUrlTest {
     @DisplayName("from 메서드는")
     inner class From {
         @Test
-        @DisplayName("http로 시작하는 유효한 URL이면 인스턴스를 생성한다")
+        @DisplayName("http 또는 https로 시작하는 유효한 URL이면 인스턴스를 생성한다")
         fun createLogoUrlSuccessfully() {
             val url = "https://example.com/logo.png"
             val logoUrl = CompanyLogoUrl.from(url)
@@ -21,16 +21,31 @@ class CompanyLogoUrlTest {
         }
 
         @Test
-        @DisplayName("http로 시작하지 않으면 예외를 발생시킨다")
-        fun throwExceptionWhenInvalidUrl() {
-            val invalidUrl = "ftp://example.com/logo.png"
+        @DisplayName("지원하지 않는 scheme이면 예외를 발생시킨다 (ftp 등)")
+        fun throwExceptionForUnsupportedScheme() {
+            val invalidSchemeUrl = "ftp://example.com/logo.png"
 
             val exception =
                 assertThrows<InternshipException> {
-                    CompanyLogoUrl.from(invalidUrl)
+                    CompanyLogoUrl.from(invalidSchemeUrl)
                 }
 
-            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_COMPANY_LOGO_URL)
+            assertThat(exception.errorCode)
+                .isEqualTo(InternshipErrorCode.UNSUPPORTED_COMPANY_LOGO_URL_SCHEME)
+        }
+
+        @Test
+        @DisplayName("URL 형식이 잘못된 경우 예외를 발생시킨다")
+        fun throwExceptionForMalformedUrl() {
+            val malformedUrl = "://not-a-valid-url"
+
+            val exception =
+                assertThrows<InternshipException> {
+                    CompanyLogoUrl.from(malformedUrl)
+                }
+
+            assertThat(exception.errorCode)
+                .isEqualTo(InternshipErrorCode.INVALID_COMPANY_LOGO_URL_FORMAT)
         }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrlTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrlTest.kt
@@ -1,0 +1,36 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CompanyLogoUrlTest {
+    @Nested
+    @DisplayName("from 메서드는")
+    inner class From {
+        @Test
+        @DisplayName("http로 시작하는 유효한 URL이면 인스턴스를 생성한다")
+        fun createLogoUrlSuccessfully() {
+            val url = "https://example.com/logo.png"
+            val logoUrl = CompanyLogoUrl.from(url)
+
+            assertThat(logoUrl.value).isEqualTo(url)
+            assertThat(logoUrl.toString()).isEqualTo(url)
+        }
+
+        @Test
+        @DisplayName("http로 시작하지 않으면 예외를 발생시킨다")
+        fun throwExceptionWhenInvalidUrl() {
+            val invalidUrl = "ftp://example.com/logo.png"
+
+            val exception =
+                assertThrows<InternshipException> {
+                    CompanyLogoUrl.from(invalidUrl)
+                }
+
+            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_COMPANY_LOGO_URL)
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description

- 기업 로고 이미지 주소를 표현하는 VO `CompanyLogoUrl`을 구현했습니다.
- 유효성 검증을 통해 `http` 또는 `https`로 시작하는 주소만 허용하며, 이를 만족하지 않으면 `InternshipException`을 발생시킵니다.
- 도메인 일관성을 위해 기존 VO들과 동일한 방식(불변성, 정적 팩토리 메서드, equals/hashCode 재정의 등)으로 구성하였으며, JPA 내장 타입으로 사용하기 위해 `@Embeddable`을 적용했습니다.
- 예외 처리를 위해 `InternshipErrorCode`에 `INVALID_COMPANY_LOGO_URL` 항목을 추가했습니다.

---

# 💭 Thoughts

- 도메인 내부에서 신뢰할 수 있는 상태로 URL을 다루기 위해 값을 VO로 감쌌습니다.
- 단순 문자열이 아닌 객체로 다룸으로써 이후 로직에서 의미를 명확히 하고, 추후 URL 규칙 변경에도 대응이 쉬운 구조를 갖추었습니다.
- 기존 `InternshipAnnouncement` 관련 VO들과 동일한 패턴을 적용하여 일관성을 유지했습니다.

---

# ✅ Testing Result

![스크린샷 2025-05-20 오후 11 43 10](https://github.com/user-attachments/assets/4cd447ab-cde2-428a-beed-84641990dbe0)

---

# 🗂 Related Issue

- closes #60
