### PR TITLE
[✨feat] InternshipAnnouncementUrl VO 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyLogoUrl.kt
@@ -1,6 +1,8 @@
 package com.terning.server.kotlin.domain.internshipAnnouncement
 
 import jakarta.persistence.Embeddable
+import java.net.URI
+import java.net.URISyntaxException
 
 @Embeddable
 class CompanyLogoUrl private constructor(
@@ -10,19 +12,27 @@ class CompanyLogoUrl private constructor(
         validateUrl(value)
     }
 
-    companion object {
-        fun from(value: String): CompanyLogoUrl = CompanyLogoUrl(value)
-
-        private fun validateUrl(value: String) {
-            if (!value.startsWith("http")) {
-                throw InternshipException(InternshipErrorCode.INVALID_COMPANY_LOGO_URL)
-            }
-        }
-    }
-
     override fun equals(other: Any?): Boolean = this === other || (other is CompanyLogoUrl && value == other.value)
 
     override fun hashCode(): Int = value.hashCode()
 
     override fun toString(): String = value
+
+    companion object {
+        private val ALLOWED_SCHEMES = setOf("http", "https")
+
+        fun from(value: String): CompanyLogoUrl = CompanyLogoUrl(value)
+
+        private fun validateUrl(value: String) {
+            try {
+                val uri = URI(value)
+                val scheme = uri.scheme?.lowercase()
+                if (scheme !in ALLOWED_SCHEMES) {
+                    throw InternshipException(InternshipErrorCode.UNSUPPORTED_COMPANY_LOGO_URL_SCHEME)
+                }
+            } catch (e: URISyntaxException) {
+                throw InternshipException(InternshipErrorCode.INVALID_COMPANY_LOGO_URL_FORMAT)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrl.kt
@@ -1,0 +1,28 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class InternshipAnnouncementUrl private constructor(
+    val value: String,
+) {
+    init {
+        validateUrl(value)
+    }
+
+    companion object {
+        fun from(value: String): InternshipAnnouncementUrl = InternshipAnnouncementUrl(value)
+
+        private fun validateUrl(value: String) {
+            if (!value.startsWith("http")) {
+                throw InternshipException(InternshipErrorCode.INVALID_ANNOUNCEMENT_URL)
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = this === other || (other is InternshipAnnouncementUrl && value == other.value)
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = value
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrl.kt
@@ -8,13 +8,11 @@ import java.net.URISyntaxException
 class InternshipAnnouncementUrl private constructor(
     val value: String,
 ) {
-
     init {
         validateUrl(value)
     }
 
-    override fun equals(other: Any?): Boolean =
-        this === other || (other is InternshipAnnouncementUrl && value == other.value)
+    override fun equals(other: Any?): Boolean = this === other || (other is InternshipAnnouncementUrl && value == other.value)
 
     override fun hashCode(): Int = value.hashCode()
 

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrl.kt
@@ -1,28 +1,40 @@
 package com.terning.server.kotlin.domain.internshipAnnouncement
 
 import jakarta.persistence.Embeddable
+import java.net.URI
+import java.net.URISyntaxException
 
 @Embeddable
 class InternshipAnnouncementUrl private constructor(
     val value: String,
 ) {
+
     init {
         validateUrl(value)
     }
 
-    companion object {
-        fun from(value: String): InternshipAnnouncementUrl = InternshipAnnouncementUrl(value)
-
-        private fun validateUrl(value: String) {
-            if (!value.startsWith("http")) {
-                throw InternshipException(InternshipErrorCode.INVALID_ANNOUNCEMENT_URL)
-            }
-        }
-    }
-
-    override fun equals(other: Any?): Boolean = this === other || (other is InternshipAnnouncementUrl && value == other.value)
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is InternshipAnnouncementUrl && value == other.value)
 
     override fun hashCode(): Int = value.hashCode()
 
     override fun toString(): String = value
+
+    companion object {
+        private val ALLOWED_SCHEMES = setOf("http", "https")
+
+        fun from(value: String): InternshipAnnouncementUrl = InternshipAnnouncementUrl(value)
+
+        private fun validateUrl(value: String) {
+            try {
+                val uri = URI(value)
+                val scheme = uri.scheme?.lowercase()
+                if (scheme !in ALLOWED_SCHEMES) {
+                    throw InternshipException(InternshipErrorCode.UNSUPPORTED_ANNOUNCEMENT_URL_SCHEME)
+                }
+            } catch (e: URISyntaxException) {
+                throw InternshipException(InternshipErrorCode.INVALID_ANNOUNCEMENT_URL_FORMAT)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -20,4 +20,5 @@ enum class InternshipErrorCode(
     INVALID_MONTH(HttpStatus.BAD_REQUEST, "월은 1~12 사이여야 합니다."),
     INVALID_YEAR(HttpStatus.BAD_REQUEST, "연도는 2025보다 커야 합니다."),
     INVALID_COMPANY_LOGO_URL(HttpStatus.BAD_REQUEST, "올바른 이미지 URL이 아닙니다."),
+    INVALID_ANNOUNCEMENT_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 공고 URL입니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipErrorCode.kt
@@ -7,7 +7,7 @@ enum class InternshipErrorCode(
     override val status: HttpStatus,
     override val message: String,
 ) : BaseErrorCode {
-    INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "마감일은 2025년 이후여야 합니다."),
+    INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "마감일은 2024년 이후여야 합니다."),
     INVALID_SCRAP_COUNT(HttpStatus.BAD_REQUEST, "스크랩 수는 음수일 수 없습니다."),
     SCRAP_COUNT_CANNOT_BE_DECREASED_BELOW_ZERO(HttpStatus.BAD_REQUEST, "스크랩 수는 0보다 작아질 수 없습니다."),
     INVALID_VIEW_COUNT(HttpStatus.BAD_REQUEST, "조회수는 음수일 수 없습니다."),
@@ -18,7 +18,9 @@ enum class InternshipErrorCode(
     INVALID_INTERNSHIP_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "인턴십 제목은 64자 이하여야 합니다."),
     INVALID_WORKING_PERIOD(HttpStatus.BAD_REQUEST, "근무 기간은 1개월 이상이어야 합니다."),
     INVALID_MONTH(HttpStatus.BAD_REQUEST, "월은 1~12 사이여야 합니다."),
-    INVALID_YEAR(HttpStatus.BAD_REQUEST, "연도는 2025보다 커야 합니다."),
-    INVALID_COMPANY_LOGO_URL(HttpStatus.BAD_REQUEST, "올바른 이미지 URL이 아닙니다."),
-    INVALID_ANNOUNCEMENT_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 공고 URL입니다."),
+    INVALID_YEAR(HttpStatus.BAD_REQUEST, "연도는 2024보다 커야 합니다."),
+    INVALID_COMPANY_LOGO_URL_FORMAT(HttpStatus.BAD_REQUEST, "회사 로고 URL 형식이 잘못되었습니다."),
+    UNSUPPORTED_COMPANY_LOGO_URL_SCHEME(HttpStatus.BAD_REQUEST, "지원하지 않는 URL scheme입니다. http 또는 https만 허용됩니다."),
+    INVALID_ANNOUNCEMENT_URL_FORMAT(HttpStatus.BAD_REQUEST, "공고 URL 형식이 잘못되었습니다."),
+    UNSUPPORTED_ANNOUNCEMENT_URL_SCHEME(HttpStatus.BAD_REQUEST, "지원하지 않는 공고 URL scheme입니다. http 또는 https만 허용됩니다."),
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrlTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrlTest.kt
@@ -1,0 +1,36 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class InternshipAnnouncementUrlTest {
+    @Nested
+    @DisplayName("from 메서드는")
+    inner class From {
+        @Test
+        @DisplayName("http로 시작하는 유효한 URL이면 인스턴스를 생성한다")
+        fun createAnnouncementUrlSuccessfully() {
+            val url = "https://example.com/post/123"
+            val announcementUrl = InternshipAnnouncementUrl.from(url)
+
+            assertThat(announcementUrl.value).isEqualTo(url)
+            assertThat(announcementUrl.toString()).isEqualTo(url)
+        }
+
+        @Test
+        @DisplayName("http로 시작하지 않으면 예외를 발생시킨다")
+        fun throwExceptionWhenInvalidUrl() {
+            val invalidUrl = "ftp://example.com/post/123"
+
+            val exception =
+                assertThrows<InternshipException> {
+                    InternshipAnnouncementUrl.from(invalidUrl)
+                }
+
+            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_ANNOUNCEMENT_URL)
+        }
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrlTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementUrlTest.kt
@@ -11,7 +11,7 @@ class InternshipAnnouncementUrlTest {
     @DisplayName("from 메서드는")
     inner class From {
         @Test
-        @DisplayName("http로 시작하는 유효한 URL이면 인스턴스를 생성한다")
+        @DisplayName("http 또는 https로 시작하는 유효한 URL이면 인스턴스를 생성한다")
         fun createAnnouncementUrlSuccessfully() {
             val url = "https://example.com/post/123"
             val announcementUrl = InternshipAnnouncementUrl.from(url)
@@ -21,16 +21,31 @@ class InternshipAnnouncementUrlTest {
         }
 
         @Test
-        @DisplayName("http로 시작하지 않으면 예외를 발생시킨다")
-        fun throwExceptionWhenInvalidUrl() {
-            val invalidUrl = "ftp://example.com/post/123"
+        @DisplayName("지원하지 않는 scheme이면 예외를 발생시킨다 (ftp 등)")
+        fun throwExceptionForUnsupportedScheme() {
+            val invalidSchemeUrl = "ftp://example.com/post/123"
 
             val exception =
                 assertThrows<InternshipException> {
-                    InternshipAnnouncementUrl.from(invalidUrl)
+                    InternshipAnnouncementUrl.from(invalidSchemeUrl)
                 }
 
-            assertThat(exception.errorCode).isEqualTo(InternshipErrorCode.INVALID_ANNOUNCEMENT_URL)
+            assertThat(exception.errorCode)
+                .isEqualTo(InternshipErrorCode.UNSUPPORTED_ANNOUNCEMENT_URL_SCHEME)
+        }
+
+        @Test
+        @DisplayName("URL 형식이 잘못된 경우 예외를 발생시킨다")
+        fun throwExceptionForMalformedUrl() {
+            val malformedUrl = "://invalid-url"
+
+            val exception =
+                assertThrows<InternshipException> {
+                    InternshipAnnouncementUrl.from(malformedUrl)
+                }
+
+            assertThat(exception.errorCode)
+                .isEqualTo(InternshipErrorCode.INVALID_ANNOUNCEMENT_URL_FORMAT)
         }
     }
 }


### PR DESCRIPTION
# 📄 Work Description  
- 인턴십 공고 상세 페이지 URL을 표현하는 VO `InternshipAnnouncementUrl`을 구현했습니다.  
- http 또는 https로 시작하는 URL만 유효한 값으로 허용하며, 그렇지 않으면 `InternshipException`을 발생시킵니다.  
- VO는 불변 객체로 설계되었고, JPA 내장 타입으로 사용될 수 있도록 `@Embeddable`을 적용했습니다.  
- 예외 처리 일관성을 위해 `InternshipErrorCode`에 `INVALID_ANNOUNCEMENT_URL` 항목을 추가했습니다.

---

# 💭 Thoughts  
- 문자열 URL을 도메인 내 VO로 감싸도록 하여 유효하지 않은 값이 진입하는 것을 방지하고자 했습니다.  
- 도메인 유효성 검증 책임을 VO 내부로 넣어 신뢰 가능한 객체만 다루도록 했습니다.  
- 기존의 VO 패턴과 동일하게 구조화하여 일관성과 재사용성을 확보했습니다.

---

# ✅ Testing Result  
![스크린샷 2025-05-20 오후 11 49 25](https://github.com/user-attachments/assets/b2547a61-f5fa-4c29-bbb0-56fe8d51b574)

---

# 🗂 Related Issue  
- closed #62 
