### PR TITLE
[✨feat] Company 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/Company.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/Company.kt
@@ -1,0 +1,46 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Embedded
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+@Embeddable
+class Company private constructor(
+    @Embedded
+    @Column(name = "companyInfo")
+    val name: CompanyName,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "companyCategory")
+    val category: CompanyCategory,
+    @Embedded
+    @Column(name = "companyImage")
+    val logoUrl: CompanyLogoUrl,
+) {
+    companion object {
+        fun of(
+            name: CompanyName,
+            category: CompanyCategory,
+            logoUrl: CompanyLogoUrl,
+        ): Company = Company(name, category, logoUrl)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return this === other || (
+            other is Company &&
+                name == other.name &&
+                category == other.category &&
+                logoUrl == other.logoUrl
+        )
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + category.hashCode()
+        result = 31 * result + logoUrl.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "${name.value} (${category.description})"
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/CompanyTest.kt
@@ -1,0 +1,43 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CompanyTest {
+    @Nested
+    @DisplayName("Company.of 메서드는")
+    inner class Of {
+        @Test
+        @DisplayName("CompanyName, CompanyCategory, CompanyLogoUrl로 Company를 생성한다")
+        fun createCompanySuccessfully() {
+            // given
+            val name = CompanyName.from("카카오페이")
+            val category = CompanyCategory.LARGE_AND_MEDIUM_COMPANIES
+            val logoUrl = CompanyLogoUrl.from("https://example.com/logo.png")
+
+            // when
+            val company = Company.of(name, category, logoUrl)
+
+            // then
+            assertThat(company.name).isEqualTo(name)
+            assertThat(company.category).isEqualTo(category)
+            assertThat(company.logoUrl).isEqualTo(logoUrl)
+        }
+    }
+
+    @Test
+    @DisplayName("toString은 '회사명 (설명)' 형식으로 출력한다")
+    fun toStringShouldFormatCorrectly() {
+        // given
+        val name = CompanyName.from("카카오페이")
+        val category = CompanyCategory.LARGE_AND_MEDIUM_COMPANIES
+        val logoUrl = CompanyLogoUrl.from("https://example.com/logo.png")
+
+        val company = Company.of(name, category, logoUrl)
+
+        // then
+        assertThat(company.toString()).isEqualTo("카카오페이 (대기업/중견기업)")
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- `Company` VO를 구현하여 `CompanyName`, `CompanyCategory`, `CompanyLogoUrl`을 하나의 불변 객체로 묶었습니다.  
- `@Embeddable`로 선언하여 JPA 내장 타입으로 사용 가능하며, `InternshipAnnouncement` 등에서 회사 정보를 하나의 객체로 표현할 수 있습니다.  
- `equals`, `hashCode`, `toString` 메서드를 재정의하여 값 객체로서의 동등성 비교 및 출력 형식을 정의했습니다.  
- 정적 팩토리 메서드 `of()`를 제공하여 명시적이고 안전한 생성 방식으로 유도합니다.  
- 각 필드에 `@Embedded`, `@Column`, `@Enumerated` 어노테이션을 명시하여 DB 매핑 명확화를 진행했습니다.

# 💭 Thoughts  
- `InternshipAnnouncementStartDate`처럼 의미 있는 단위를 값 객체(Value Object)로 분리함으로써 응집도를 높였습니다.  
- 회사명, 로고, 카테고리처럼 함께 묶여 의미를 갖는 정보들을 하나의 VO로 표현하는 것이 가독성과 유지보수 측면에서 더 적절하다고 판단했습니다.  
- 이후 `Company` 관련 정보가 확장될 경우에도 하나의 단위로 다룰 수 있어 설계 유연성이 향상됩니다.  
- 기존에 정의돼 있던 컬럼 이름들이 실제 의미를 충분히 드러내지 못하는 것 같았습니다. 예를 들어, 이미지 URL인데도 `companyImage`, 기업명인데 `companyInfo`처럼 애매하게 표현되어 있었는데요,  
  이러한 필드명은 DB 상에서는 그대로 유지하되, 애플리케이션 단에서는 도메인의 의미에 맞는 이름으로 명확히 표현해주는 게 좋다고 생각합니다. 이 부분에 대해서도 어떻게 생각하시는지 궁금합니다.


# ✅ Testing Result  
![스크린샷 2025-05-21 오전 12 06 27](https://github.com/user-attachments/assets/5c6af84a-3dbf-4fb5-8b4c-5290898a20d7)


# 🗂 Related Issue  
- closed #62
