### PR TITLE
[📦chore] GraalVM 액션 안정화를 위한 CI 설정 개선

### DIFF
--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -12,12 +12,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up GraalVM JDK 21 with native-image
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@v1.1.1
         with:
           distribution: 'graalvm-community'
-          version: '21.0.2'
+          version: '23.1.0'
           java-version: '21'
-          components: 'native-image'
 
       - name: Gradle 캐시 설정
         uses: actions/cache@v3


### PR DESCRIPTION
# 📄 Work Description  
- GitHub Actions에서 사용하는 GraalVM 설치 액션을 `@v1` → `@v1.1.1`로 명시하여 SHA 기반 캐시 실패 방지
- GraalVM 버전을 21.0.2 → 23.1.0으로 업그레이드하여 최신 안정 버전 사용
- JDK 17 이상에서는 `native-image`가 기본 포함되므로 `components: 'native-image'` 옵션 제거

# 💭 Thoughts  
- 기존에는 PR에서 수정해도 base 브랜치의 CI 설정이 사용되어 예상치 못한 버전이 설치됨  
- GraalVM 관련 CI 실패를 방지하고, 경고 없이 안정적으로 동작하도록 개선함  
