### PR TITLE
[✨feat] 스크랩 추가 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,13 +37,19 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.mysql:mysql-connector-j")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("com.h2database:h2")
+
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("io.mockk:mockk:1.13.10")
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 kotlin {
@@ -72,6 +78,10 @@ noArg {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.named("processTestAot").configure {
+    enabled = false
 }
 
 ktlint {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.h2database:h2")
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapRequest.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapRequest.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.application.scrap
+
+data class ScrapRequest(
+    val color: String,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-@Transactional(readOnly = false)
+@Transactional(readOnly = true)
 class ScrapService(
     private val scrapRepository: ScrapRepository,
     private val userRepository: UserRepository,
@@ -37,11 +37,12 @@ class ScrapService(
                 .orElseThrow { ScrapException(ScrapErrorCode.USER_NOT_FOUND) }
 
         val color = Color.from(request.color)
-        val scrap = Scrap.of(
-            user = user,
-            internshipAnnouncement = announcement,
-            color = color,
-        )
+        val scrap =
+            Scrap.of(
+                user = user,
+                internshipAnnouncement = announcement,
+                color = color,
+            )
 
         scrapRepository.save(scrap)
         announcement.increaseScrapCount()

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -37,7 +37,11 @@ class ScrapService(
                 .orElseThrow { ScrapException(ScrapErrorCode.USER_NOT_FOUND) }
 
         val color = Color.from(request.color)
-        val scrap = Scrap.of(user, announcement, color)
+        val scrap = Scrap.of(
+            user = user,
+            internshipAnnouncement = announcement,
+            color = color,
+        )
 
         scrapRepository.save(scrap)
         announcement.increaseScrapCount()

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -1,0 +1,45 @@
+package com.terning.server.kotlin.application
+
+import com.terning.server.kotlin.application.scrap.ScrapRequest
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
+import com.terning.server.kotlin.domain.scrap.Scrap
+import com.terning.server.kotlin.domain.scrap.ScrapRepository
+import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
+import com.terning.server.kotlin.domain.scrap.exception.ScrapException
+import com.terning.server.kotlin.domain.scrap.vo.Color
+import com.terning.server.kotlin.domain.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = false)
+class ScrapService(
+    private val scrapRepository: ScrapRepository,
+    private val userRepository: UserRepository,
+    private val internshipAnnouncementRepository: InternshipAnnouncementRepository,
+) {
+    @Transactional
+    fun scrap(
+        userId: Long,
+        internshipAnnouncementId: Long,
+        request: ScrapRequest,
+    ) {
+        if (scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, internshipAnnouncementId)) {
+            throw ScrapException(ScrapErrorCode.EXISTS_SCRAP_ALREADY)
+        }
+
+        val announcement =
+            internshipAnnouncementRepository.findById(internshipAnnouncementId)
+                .orElseThrow { ScrapException(ScrapErrorCode.INTERN_SHIP_ANNOUNCEMENT_NOT_FOUND) }
+
+        val user =
+            userRepository.findById(userId)
+                .orElseThrow { ScrapException(ScrapErrorCode.USER_NOT_FOUND) }
+
+        val color = Color.from(request.color)
+        val scrap = Scrap.of(user, announcement, color)
+
+        scrapRepository.save(scrap)
+        announcement.increaseScrapCount()
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -29,7 +29,7 @@ class Auth private constructor(
     val id: Long? = null,
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     val user: User,
 
     @Embedded
@@ -53,6 +53,22 @@ class Auth private constructor(
             this.refreshToken = RefreshToken(null)
         } catch (e: Exception) {
             throw AuthException(AuthErrorCode.FAILED_REFRESH_TOKEN_RESET)
+        }
+    }
+
+    companion object {
+        fun of(
+            user: User,
+            authId: AuthId,
+            authType: AuthType,
+            refreshToken: RefreshToken,
+        ): Auth {
+            return Auth(
+                user = user,
+                authId = authId,
+                authType = authType,
+                refreshToken = refreshToken,
+            )
         }
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -29,7 +29,7 @@ class Auth private constructor(
     val id: Long? = null,
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "userId", nullable = false)
     val user: User,
 
     @Embedded

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.domain.auth
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AuthRepository : JpaRepository<Auth, String>

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncement.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncement.kt
@@ -100,4 +100,32 @@ class InternshipAnnouncement(
     }
 
     override fun hashCode(): Int = id?.hashCode() ?: 0
+
+    companion object {
+        fun of(
+            title: InternshipTitle,
+            deadline: InternshipAnnouncementDeadline,
+            workingPeriod: InternshipWorkingPeriod,
+            startDate: InternshipAnnouncementStartDate,
+            url: InternshipAnnouncementUrl,
+            company: Company,
+            jobType: FilterJobType,
+            qualifications: String? = null,
+            detail: String? = null,
+            isGraduating: Boolean = false,
+        ): InternshipAnnouncement {
+            return InternshipAnnouncement(
+                title = title,
+                internshipAnnouncementDeadline = deadline,
+                workingPeriod = workingPeriod,
+                startDate = startDate,
+                url = url,
+                company = company,
+                filterJobType = jobType,
+                qualifications = qualifications,
+                detail = detail,
+                isGraduating = isGraduating,
+            )
+        }
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepository.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.domain.internshipAnnouncement
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface InternshipAnnouncementRepository : JpaRepository<InternshipAnnouncement, Long>

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepository.kt
@@ -1,0 +1,10 @@
+package com.terning.server.kotlin.domain.scrap
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ScrapRepository : JpaRepository<Scrap, Long> {
+    fun existsByInternshipAnnouncementIdAndUserId(
+        userId: Long,
+        internshipAnnouncementId: Long,
+    ): Boolean
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/exception/ScrapErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/exception/ScrapErrorCode.kt
@@ -9,4 +9,8 @@ enum class ScrapErrorCode(
 ) : BaseErrorCode {
     INVALID_COLOR(HttpStatus.BAD_REQUEST, "유효하지 않은 스크랩 색상입니다."),
     INVALID_JOB_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 직무 유형입니다."),
+
+    EXISTS_SCRAP_ALREADY(HttpStatus.BAD_REQUEST, "이미 스크랩한 공고입니다."),
+    INTERN_SHIP_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인턴 공고는 존재하지 않습니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저는 존재하지 않습니다"),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/vo/Color.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/vo/Color.kt
@@ -23,7 +23,7 @@ enum class Color(
 
     companion object {
         fun from(color: String): Color =
-            entries.firstOrNull { it.color == color }
+            entries.firstOrNull { it.color.equals(color, ignoreCase = true) }
                 ?: throw ScrapException(ScrapErrorCode.INVALID_COLOR)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/User.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/User.kt
@@ -17,7 +17,7 @@ import jakarta.persistence.Table
 
 @Entity
 @Table(name = "users")
-class User(
+class User private constructor(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
@@ -64,4 +64,18 @@ class User(
     }
 
     fun isActive(): Boolean = userState == UserState.ACTIVE
+
+    companion object {
+        fun of(
+            name: String,
+            profile: String,
+            userState: UserState = UserState.ACTIVE,
+        ): User {
+            return User(
+                name = UserName.from(name),
+                profileImage = ProfileImage.from(profile),
+                userState = userState,
+            )
+        }
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/UserRepository.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.domain.user
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserRepository : JpaRepository<User, Long>

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
@@ -22,7 +22,7 @@ class UserName(
         private const val MAX_LENGTH = 12
 
         private const val ERROR_EMPTY = "이름은 공백일 수 없습니다."
-        private const val ERROR_LENGTH = "이름은 $MIN_LENGTH~${MAX_LENGTH}자여야 합니다."
+        private val ERROR_LENGTH = "이름은 $MIN_LENGTH~${MAX_LENGTH}자여야 합니다."
 
         fun from(value: String): UserName {
             return UserName(value)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
@@ -23,5 +23,9 @@ class UserName(
 
         private const val ERROR_EMPTY = "이름은 공백일 수 없습니다."
         private const val ERROR_LENGTH = "이름은 $MIN_LENGTH~${MAX_LENGTH}자여야 합니다."
+
+        fun from(value: String): UserName {
+            return UserName(value)
+        }
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
@@ -24,8 +24,6 @@ class UserName(
         private const val ERROR_EMPTY = "이름은 공백일 수 없습니다."
         private val ERROR_LENGTH = "이름은 $MIN_LENGTH~${MAX_LENGTH}자여야 합니다."
 
-        fun from(value: String): UserName {
-            return UserName(value)
-        }
+        fun from(value: String): UserName = UserName(value)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -1,0 +1,38 @@
+package com.terning.server.kotlin.ui.api
+
+import com.terning.server.kotlin.application.ScrapService
+import com.terning.server.kotlin.application.scrap.ScrapRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/scraps")
+class ScrapController(
+    private val scrapService: ScrapService,
+) {
+    @PostMapping("/{internshipAnnouncementId}")
+    fun scrap(
+        // @AuthenticationPrincipal userId: Long,
+        @PathVariable internshipAnnouncementId: Long,
+        @RequestBody scrapRequest: ScrapRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        val userId: Long = 1 // 임시 userId
+
+        scrapService.scrap(userId, internshipAnnouncementId, scrapRequest)
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(
+                ApiResponse.success(
+                    status = HttpStatus.CREATED,
+                    message = "스크랩 추가에 성공했습니다",
+                    result = Unit,
+                ),
+            )
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -17,11 +17,11 @@ class ScrapController(
 ) {
     @PostMapping("/{internshipAnnouncementId}")
     fun scrap(
-        // @AuthenticationPrincipal userId: Long,
+        // TODO: @AuthenticationPrincipal userId: Long,
         @PathVariable internshipAnnouncementId: Long,
         @RequestBody scrapRequest: ScrapRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        val userId: Long = 1 // 임시 userId
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
         scrapService.scrap(userId, internshipAnnouncementId, scrapRequest)
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,13 +1,15 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
     driver-class-name: org.h2.Driver
     username: sa
     password:
   jpa:
+    generate-ddl: false
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
+
+
+server:
+  port: 8080

--- a/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
@@ -1,0 +1,99 @@
+package com.terning.server.kotlin.application
+
+import com.terning.server.kotlin.application.scrap.ScrapRequest
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
+import com.terning.server.kotlin.domain.scrap.Scrap
+import com.terning.server.kotlin.domain.scrap.ScrapRepository
+import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
+import com.terning.server.kotlin.domain.scrap.exception.ScrapException
+import com.terning.server.kotlin.domain.user.User
+import com.terning.server.kotlin.domain.user.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+class ScrapServiceTest {
+    private val scrapRepository: ScrapRepository = mockk()
+    private val userRepository: UserRepository = mockk()
+    private val internshipAnnouncementRepository: InternshipAnnouncementRepository = mockk()
+
+    private lateinit var scrapService: ScrapService
+
+    private val userId = 1L
+    private val announcementId = 100L
+    private val request = ScrapRequest(color = "BLUE")
+
+    @BeforeEach
+    fun setUp() {
+        scrapService = ScrapService(scrapRepository, userRepository, internshipAnnouncementRepository)
+    }
+
+    @Test
+    @DisplayName("이미 스크랩한 경우 예외가 발생한다")
+    fun scrapFailsIfAlreadyScrapped() {
+        every { scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, announcementId) } returns true
+
+        val exception =
+            assertThrows(ScrapException::class.java) {
+                scrapService.scrap(userId, announcementId, request)
+            }
+
+        assertEquals(ScrapErrorCode.EXISTS_SCRAP_ALREADY, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("공고를 찾을 수 없으면 예외가 발생한다")
+    fun scrapFailsIfAnnouncementNotFound() {
+        every { scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, announcementId) } returns false
+        every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.empty()
+
+        val exception =
+            assertThrows(ScrapException::class.java) {
+                scrapService.scrap(userId, announcementId, request)
+            }
+
+        assertEquals(ScrapErrorCode.INTERN_SHIP_ANNOUNCEMENT_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("사용자를 찾을 수 없으면 예외가 발생한다")
+    fun scrapFailsIfUserNotFound() {
+        every { scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, announcementId) } returns false
+        every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(mockk())
+        every { userRepository.findById(userId) } returns Optional.empty()
+
+        val exception =
+            assertThrows(ScrapException::class.java) {
+                scrapService.scrap(userId, announcementId, request)
+            }
+
+        assertEquals(ScrapErrorCode.USER_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("스크랩에 성공한다")
+    fun scrapSucceeds() {
+        val user = mockk<User>()
+        val announcement = mockk<InternshipAnnouncement>(relaxed = true)
+        val scrapSlot = slot<Scrap>()
+
+        every { scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, announcementId) } returns false
+        every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(announcement)
+        every { userRepository.findById(userId) } returns Optional.of(user)
+        every { scrapRepository.save(capture(scrapSlot)) } returns mockk()
+
+        scrapService.scrap(userId, announcementId, request)
+
+        verify { announcement.increaseScrapCount() }
+
+        assertEquals("#4AA9F2", scrapSlot.captured.hexColor())
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
@@ -7,6 +7,7 @@ import com.terning.server.kotlin.domain.scrap.Scrap
 import com.terning.server.kotlin.domain.scrap.ScrapRepository
 import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
 import com.terning.server.kotlin.domain.scrap.exception.ScrapException
+import com.terning.server.kotlin.domain.scrap.vo.Color
 import com.terning.server.kotlin.domain.user.User
 import com.terning.server.kotlin.domain.user.UserRepository
 import io.mockk.every
@@ -94,6 +95,6 @@ class ScrapServiceTest {
 
         verify { announcement.increaseScrapCount() }
 
-        assertEquals("#4AA9F2", scrapSlot.captured.hexColor())
+        assertEquals(Color.BLUE.toHexString(), scrapSlot.captured.hexColor())
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/domain/user/UserTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/user/UserTest.kt
@@ -77,9 +77,9 @@ class UserTest {
         profile: ProfileImage = ProfileImage.BASIC,
         userState: UserState = UserState.ACTIVE,
     ): User {
-        return User(
-            name = UserName(name),
-            profileImage = profile,
+        return User.of(
+            name = name,
+            profile = profile.value,
             userState = userState,
         )
     }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
@@ -1,0 +1,53 @@
+package com.terning.server.kotlin.ui.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.terning.server.kotlin.application.ScrapService
+import com.terning.server.kotlin.application.scrap.ScrapRequest
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+
+@WebMvcTest(ScrapController::class)
+@ActiveProfiles("test")
+class ScrapControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var scrapService: ScrapService
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var scrapRequest: ScrapRequest
+
+    @BeforeEach
+    fun setUp() {
+        scrapRequest = ScrapRequest(color = "BLUE")
+    }
+
+    @Test
+    @DisplayName("스크랩을 생성한다")
+    fun createScrap() {
+        val internshipAnnouncementId = 1L
+        val userId = 1L
+        every { scrapService.scrap(userId, internshipAnnouncementId, scrapRequest) } just runs
+
+        mockMvc.post("/api/v1/scraps/$internshipAnnouncementId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(scrapRequest)
+        }.andExpect {
+            status { isCreated() }
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- 스크랩 추가 API를 구현했습니다.  
- 인턴십 공고와 사용자 정보를 바탕으로 스크랩을 생성하며, 중복 스크랩 방지를 위해 사전 검증 로직을 포함했습니다.  
- 요청 DTO(`ScrapRequest`)에 color 값을 받으며, 대소문자 구분 없이 색상을 매핑할 수 있도록 개선했습니다.  
- 관련된 예외 케이스(중복 스크랩, 공고 없음, 사용자 없음)를 처리하는 `ScrapException`도 함께 적용했습니다.  
- 정적 팩토리 메서드(`of`, `from`)를 각 도메인 객체에 적용해 객체 생성을 명확히 했습니다.  

# 💭 Thoughts  
- `userId`를 임시로 하드코딩한 상태인데, 이후 인증 정보를 기반으로 `@AuthenticationPrincipal` 등으로 교체하는 작업이 필요합니다.  
- PR을 더 작은 단위로 나누고 싶었지만, API 하나를 처음부터 끝까지 구현하는 과정에서는 흐름을 이해하는 게 더 중요하다고 판단해 API 단위로 PR을 구성했어요. 유빈님은 어떻게 생각하시나요? 앞으로의 PR 전략에 대해서도 함께 이야기해보면 좋을 것 같아요! 😊  
- 구현하면서 흥미로웠던 점은 자바에서는 생성자 주입을 위해 `@RequiredArgsConstructor`를 사용했었는데, 코틀린에서는 명시적으로 애너테이션 없이도 바로 의존성 주입이 가능하다는 점이 새로웠어요.  
- 이제 각 서비스 클래스 안에 여러 API가 생기면, 메서드 수가 많아져 가시성에 영향을 줄 수 있다는 고민이 생겼어요.  
  그래서 하나의 API 메서드마다 인터페이스를 따로 만들어 응집도 있게 분리하는 것도 고려해봤는데요,  
  이렇게 되면 관심사 분리는 잘 되지만 반대로 인터페이스와 구현체가 너무 많아져서 협업 시 추상화 구조를 파악하기 어려울 수도 있겠다는 고민도 들었어요.  
  예를 들어, 스크랩 서비스에 API가 4개 있다면 각 기능별 인터페이스 4개와 구현체 4개가 생기는 구조인데요,  
  이런 구조가 협업과 유지보수에 도움이 될지, 혹은 오히려 복잡도를 높일지 같이 이야기 나눠보고 싶습니다! 🙌


# ✅ Testing Result  
![스크린샷](https://github.com/user-attachments/assets/9e3e4eb0-bd06-48f3-9c21-8fdfa15056e5)

# 🗂 Related Issue  
- closed #80
