### PR TITLE
[✨feat] 스크랩 색상 수정 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -1,6 +1,7 @@
 package com.terning.server.kotlin.application
 
 import com.terning.server.kotlin.application.scrap.ScrapRequest
+import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
 import com.terning.server.kotlin.domain.scrap.Scrap
 import com.terning.server.kotlin.domain.scrap.ScrapRepository
@@ -22,7 +23,7 @@ class ScrapService(
     fun scrap(
         userId: Long,
         internshipAnnouncementId: Long,
-        request: ScrapRequest,
+        scrapRequest: ScrapRequest,
     ) {
         if (scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, internshipAnnouncementId)) {
             throw ScrapException(ScrapErrorCode.EXISTS_SCRAP_ALREADY)
@@ -36,10 +37,26 @@ class ScrapService(
             userRepository.findById(userId)
                 .orElseThrow { ScrapException(ScrapErrorCode.USER_NOT_FOUND) }
 
-        val color = Color.from(request.color)
+        val color = Color.from(scrapRequest.color)
         val scrap = Scrap.of(user, announcement, color)
 
         scrapRepository.save(scrap)
         announcement.increaseScrapCount()
+    }
+
+    @Transactional
+    fun updateScrap(
+        userId: Long,
+        internshipAnnouncementId: Long,
+        scrapUpdateRequest: ScrapUpdateRequest,
+    ) {
+        val scrap =
+            scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, internshipAnnouncementId)
+                ?: throw ScrapException(ScrapErrorCode.SCRAP_NOT_FOUND)
+
+        val color = Color.from(scrapUpdateRequest.color)
+        scrap.updateColor(color)
+
+        scrapRepository.save(scrap)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-@Transactional(readOnly = false)
+@Transactional(readOnly = true)
 class ScrapService(
     private val scrapRepository: ScrapRepository,
     private val userRepository: UserRepository,
@@ -38,7 +38,12 @@ class ScrapService(
                 .orElseThrow { ScrapException(ScrapErrorCode.USER_NOT_FOUND) }
 
         val color = Color.from(scrapRequest.color)
-        val scrap = Scrap.of(user, announcement, color)
+        val scrap =
+            Scrap.of(
+                user = user,
+                internshipAnnouncement = announcement,
+                color = color,
+            )
 
         scrapRepository.save(scrap)
         announcement.increaseScrapCount()

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapUpdateRequest.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapUpdateRequest.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.application.scrap
+
+data class ScrapUpdateRequest(
+    val color: String,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Scrap.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Scrap.kt
@@ -2,6 +2,8 @@ package com.terning.server.kotlin.domain.scrap
 
 import com.terning.server.kotlin.domain.common.BaseRootEntity
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
+import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
+import com.terning.server.kotlin.domain.scrap.exception.ScrapException
 import com.terning.server.kotlin.domain.scrap.vo.Color
 import com.terning.server.kotlin.domain.user.User
 import jakarta.persistence.Column
@@ -36,11 +38,14 @@ class Scrap private constructor(
     @Column(nullable = false)
     private var color: Color,
 ) : BaseRootEntity() {
-    fun changeColor(to: Color) {
-        this.color = to
-    }
-
     fun hexColor(): String = color.toHexString()
+
+    fun updateColor(newColor: Color) {
+        if (this.color == newColor) {
+            throw ScrapException(ScrapErrorCode.COLOR_UNSUPPORTED)
+        }
+        this.color = newColor
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Scrap.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/Scrap.kt
@@ -2,8 +2,6 @@ package com.terning.server.kotlin.domain.scrap
 
 import com.terning.server.kotlin.domain.common.BaseRootEntity
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
-import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
-import com.terning.server.kotlin.domain.scrap.exception.ScrapException
 import com.terning.server.kotlin.domain.scrap.vo.Color
 import com.terning.server.kotlin.domain.user.User
 import jakarta.persistence.Column
@@ -41,9 +39,7 @@ class Scrap private constructor(
     fun hexColor(): String = color.toHexString()
 
     fun updateColor(newColor: Color) {
-        if (this.color == newColor) {
-            throw ScrapException(ScrapErrorCode.COLOR_UNSUPPORTED)
-        }
+        if (this.color == newColor) return
         this.color = newColor
     }
 

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepository.kt
@@ -7,4 +7,9 @@ interface ScrapRepository : JpaRepository<Scrap, Long> {
         userId: Long,
         internshipAnnouncementId: Long,
     ): Boolean
+
+    fun findByInternshipAnnouncementIdAndUserId(
+        userId: Long,
+        internshipAnnouncementId: Long,
+    ): Scrap?
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/exception/ScrapErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/exception/ScrapErrorCode.kt
@@ -13,4 +13,7 @@ enum class ScrapErrorCode(
     EXISTS_SCRAP_ALREADY(HttpStatus.BAD_REQUEST, "이미 스크랩한 공고입니다."),
     INTERN_SHIP_ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인턴 공고는 존재하지 않습니다"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저는 존재하지 않습니다"),
+
+    SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스크랩은 존재하지 않습니다"),
+    COLOR_UNSUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 색상입니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/exception/ScrapErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/exception/ScrapErrorCode.kt
@@ -15,5 +15,4 @@ enum class ScrapErrorCode(
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저는 존재하지 않습니다"),
 
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스크랩은 존재하지 않습니다"),
-    COLOR_UNSUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 색상입니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -40,11 +40,11 @@ class ScrapController(
 
     @PatchMapping("/{internshipAnnouncementId}")
     fun updateScrap(
-        // @AuthenticationPrincipal userId: Long,
+        // TODO: @AuthenticationPrincipal userId: Long,
         @PathVariable internshipAnnouncementId: Long,
         @RequestBody scrapUpdateRequest: ScrapUpdateRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        val userId: Long = 1 // 임시 userId
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
         scrapService.updateScrap(userId, internshipAnnouncementId, scrapUpdateRequest)
 

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -2,8 +2,10 @@ package com.terning.server.kotlin.ui.api
 
 import com.terning.server.kotlin.application.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapRequest
+import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -31,6 +33,27 @@ class ScrapController(
                 ApiResponse.success(
                     status = HttpStatus.CREATED,
                     message = "스크랩 추가에 성공했습니다",
+                    result = Unit,
+                ),
+            )
+    }
+
+    @PatchMapping("/{internshipAnnouncementId}")
+    fun updateScrap(
+        // @AuthenticationPrincipal userId: Long,
+        @PathVariable internshipAnnouncementId: Long,
+        @RequestBody scrapUpdateRequest: ScrapUpdateRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        val userId: Long = 1 // 임시 userId
+
+        scrapService.updateScrap(userId, internshipAnnouncementId, scrapUpdateRequest)
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(
+                ApiResponse.success(
+                    status = HttpStatus.OK,
+                    message = "스크랩 수정에 성공했습니다",
                     result = Unit,
                 ),
             )

--- a/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ScrapTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ScrapTest.kt
@@ -1,0 +1,85 @@
+package com.terning.server.kotlin.domain.scrap
+
+import com.terning.server.kotlin.domain.filter.vo.FilterJobType
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.Company
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.CompanyCategory
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.CompanyLogoUrl
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.CompanyName
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnnouncementDeadline
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnnouncementMonth
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnnouncementStartDate
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnnouncementUrl
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnnouncementYear
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipTitle
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipWorkingPeriod
+import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
+import com.terning.server.kotlin.domain.scrap.exception.ScrapException
+import com.terning.server.kotlin.domain.scrap.vo.Color
+import com.terning.server.kotlin.domain.user.User
+import com.terning.server.kotlin.domain.user.vo.UserState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ScrapTest {
+    private val user = User.of("testUser", "smart", UserState.ACTIVE)
+
+    private val internshipAnnouncement: InternshipAnnouncement =
+        run {
+            val title = InternshipTitle.from("백엔드 인턴 모집")
+            val deadline = InternshipAnnouncementDeadline.from(LocalDate.of(2025, 6, 30))
+            val workingPeriod = InternshipWorkingPeriod.from(3)
+            val startDate =
+                InternshipAnnouncementStartDate.of(
+                    InternshipAnnouncementYear.from(2025),
+                    InternshipAnnouncementMonth.from(7),
+                )
+            val url = InternshipAnnouncementUrl.from("https://example.com/internship")
+            val company =
+                Company.of(
+                    name = CompanyName.from("터닝"),
+                    category = CompanyCategory.from("대기업/중견기업"),
+                    logoUrl = CompanyLogoUrl.from("https://example.com/logo.png"),
+                )
+            val jobType = FilterJobType.from("total")
+
+            InternshipAnnouncement.of(
+                title = title,
+                deadline = deadline,
+                workingPeriod = workingPeriod,
+                startDate = startDate,
+                url = url,
+                company = company,
+                jobType = jobType,
+                qualifications = "자바 가능자 우대",
+                detail = "스프링부트 기반 개발 참여",
+                isGraduating = true,
+            )
+        }
+
+    @Test
+    @DisplayName("다른 색상으로 변경하면 성공한다")
+    fun updateColorSuccess() {
+        val scrap = Scrap.of(user, internshipAnnouncement, Color.BLUE)
+
+        scrap.updateColor(Color.RED)
+
+        assertEquals(Color.RED.toHexString(), scrap.hexColor())
+    }
+
+    @Test
+    @DisplayName("같은 색상으로 변경하면 예외가 발생한다")
+    fun updateColorFailsIfSameColor() {
+        val scrap = Scrap.of(user, internshipAnnouncement, Color.BLUE)
+
+        val exception =
+            assertThrows(ScrapException::class.java) {
+                scrap.updateColor(Color.BLUE)
+            }
+
+        assertEquals(ScrapErrorCode.COLOR_UNSUPPORTED, exception.errorCode)
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ScrapTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/scrap/ScrapTest.kt
@@ -13,13 +13,10 @@ import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnno
 import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnnouncementYear
 import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipTitle
 import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipWorkingPeriod
-import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
-import com.terning.server.kotlin.domain.scrap.exception.ScrapException
 import com.terning.server.kotlin.domain.scrap.vo.Color
 import com.terning.server.kotlin.domain.user.User
 import com.terning.server.kotlin.domain.user.vo.UserState
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -68,18 +65,5 @@ class ScrapTest {
         scrap.updateColor(Color.RED)
 
         assertEquals(Color.RED.toHexString(), scrap.hexColor())
-    }
-
-    @Test
-    @DisplayName("같은 색상으로 변경하면 예외가 발생한다")
-    fun updateColorFailsIfSameColor() {
-        val scrap = Scrap.of(user, internshipAnnouncement, Color.BLUE)
-
-        val exception =
-            assertThrows(ScrapException::class.java) {
-                scrap.updateColor(Color.BLUE)
-            }
-
-        assertEquals(ScrapErrorCode.COLOR_UNSUPPORTED, exception.errorCode)
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.terning.server.kotlin.application.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapRequest
+import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import io.mockk.every
 import io.mockk.just
 import io.mockk.runs
@@ -15,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(ScrapController::class)
@@ -30,10 +32,12 @@ class ScrapControllerTest {
     private lateinit var objectMapper: ObjectMapper
 
     private lateinit var scrapRequest: ScrapRequest
+    private lateinit var scrapUpdateRequest: ScrapUpdateRequest
 
     @BeforeEach
     fun setUp() {
         scrapRequest = ScrapRequest(color = "BLUE")
+        scrapUpdateRequest = ScrapUpdateRequest(color = "RED")
     }
 
     @Test
@@ -48,6 +52,21 @@ class ScrapControllerTest {
             content = objectMapper.writeValueAsString(scrapRequest)
         }.andExpect {
             status { isCreated() }
+        }
+    }
+
+    @Test
+    @DisplayName("스크랩 색상을 업데이트한다")
+    fun updateScrap() {
+        val internshipAnnouncementId = 1L
+        val userId = 1L
+        every { scrapService.updateScrap(userId, internshipAnnouncementId, scrapUpdateRequest) } just runs
+
+        mockMvc.patch("/api/v1/scraps/$internshipAnnouncementId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(scrapUpdateRequest)
+        }.andExpect {
+            status { isOk() }
         }
     }
 }


### PR DESCRIPTION
# 📄 Work Description  
- 스크랩 색상 수정 API를 구현했습니다.  
- 기존과의 통일성을 위해 추가/삭제와 동일하게 `internshipAnnouncementId`를 path로 받도록 구성했어요.  
- 스크랩이 존재하지 않거나, 동일 색상으로 수정할 경우에 대한 예외 처리도 함께 포함되어 있어요!

---

# 💭 Thoughts

이번 작업에서는 스크랩 색상 변경 기능을 추가하면서, 기존 스크랩 추가/삭제와 API 구조를 통일시켜 일관성을 유지하고자 했어요.  
덕분에 path parameter로 `internshipAnnouncementId`를 받도록 설계했습니다!

- 색상 변경 로직(`Scrap.updateColor`)에서 **같은 색상으로 요청한 경우 예외를 던지도록 처리**했어요.
  - 이 부분은 클라이언트에서 미리 막는 게 맞을지?
  - 혹은 같은 색상이더라도 200 OK로 응답하는 게 좋을지?
  - 유빈님과 함께 응답 설계 방향을 이야기해보면 좋을 것 같아요.

- 또한, 색상 변경 시 `scrapRepository.save()`를 명시적으로 호출했는데요,
  - JPA의 **변경 감지(Dirty Checking)** 으로도 충분할지?
  - 명시적으로 save 하는 게 오히려 의도를 명확히 보여주는 건 아닐지?
  - 이 부분도 팀 기준을 정해두면 다른 작업에도 일관성을 줄 수 있을 것 같아요!

# ✅ Testing Result  
<img width="375" alt="스크린샷 2025-06-03 오후 8 01 42" src="https://github.com/user-attachments/assets/bffbaa51-2d0a-41c5-8011-640a08e52242" />


# 🗂 Related Issue  
- closed #83 
