### PR TITLE
[✨feat] 스크랩 취소 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -59,4 +59,21 @@ class ScrapService(
 
         scrapRepository.save(scrap)
     }
+
+    @Transactional
+    fun cancelScrap(
+        userId: Long,
+        internshipAnnouncementId: Long,
+    ) {
+        val scrap =
+            scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, internshipAnnouncementId)
+                ?: throw ScrapException(ScrapErrorCode.SCRAP_NOT_FOUND)
+
+        val announcement =
+            internshipAnnouncementRepository.findById(internshipAnnouncementId)
+                .orElseThrow { ScrapException(ScrapErrorCode.INTERN_SHIP_ANNOUNCEMENT_NOT_FOUND) }
+
+        announcement.decreaseScrapCount()
+        scrapRepository.delete(scrap)
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -25,7 +25,7 @@ class ScrapService(
         internshipAnnouncementId: Long,
         scrapRequest: ScrapRequest,
     ) {
-        if (scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, internshipAnnouncementId)) {
+        if (scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, internshipAnnouncementId)) {
             throw ScrapException(ScrapErrorCode.EXISTS_SCRAP_ALREADY)
         }
 
@@ -51,7 +51,7 @@ class ScrapService(
         scrapUpdateRequest: ScrapUpdateRequest,
     ) {
         val scrap =
-            scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, internshipAnnouncementId)
+            scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, internshipAnnouncementId)
                 ?: throw ScrapException(ScrapErrorCode.SCRAP_NOT_FOUND)
 
         val color = Color.from(scrapUpdateRequest.color)
@@ -66,7 +66,7 @@ class ScrapService(
         internshipAnnouncementId: Long,
     ) {
         val scrap =
-            scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, internshipAnnouncementId)
+            scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, internshipAnnouncementId)
                 ?: throw ScrapException(ScrapErrorCode.SCRAP_NOT_FOUND)
 
         val announcement =

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepository.kt
@@ -3,12 +3,12 @@ package com.terning.server.kotlin.domain.scrap
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ScrapRepository : JpaRepository<Scrap, Long> {
-    fun existsByInternshipAnnouncementIdAndUserId(
+    fun existsByUserIdAndInternshipAnnouncementId(
         userId: Long,
         internshipAnnouncementId: Long,
     ): Boolean
 
-    fun findByInternshipAnnouncementIdAndUserId(
+    fun findByUserIdAndInternshipAnnouncementId(
         userId: Long,
         internshipAnnouncementId: Long,
     ): Scrap?

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -5,6 +5,7 @@ import com.terning.server.kotlin.application.scrap.ScrapRequest
 import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -54,6 +55,26 @@ class ScrapController(
                 ApiResponse.success(
                     status = HttpStatus.OK,
                     message = "스크랩 수정에 성공했습니다",
+                    result = Unit,
+                ),
+            )
+    }
+
+    @DeleteMapping("/{internshipAnnouncementId}")
+    fun cancelScrap(
+        // @AuthenticationPrincipal userId: Long,
+        @PathVariable internshipAnnouncementId: Long,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        val userId: Long = 1 // 임시 userId
+
+        scrapService.cancelScrap(userId, internshipAnnouncementId)
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .body(
+                ApiResponse.success(
+                    status = HttpStatus.NO_CONTENT,
+                    message = "스크랩 취소에 성공했습니다",
                     result = Unit,
                 ),
             )

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -74,7 +74,7 @@ class ScrapController(
                 status = HttpStatus.OK,
                 message = "스크랩 취소에 성공했습니다",
                 result = Unit,
-            )
+            ),
         )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -69,14 +69,12 @@ class ScrapController(
 
         scrapService.cancelScrap(userId, internshipAnnouncementId)
 
-        return ResponseEntity
-            .status(HttpStatus.NO_CONTENT)
-            .body(
-                ApiResponse.success(
-                    status = HttpStatus.NO_CONTENT,
-                    message = "스크랩 취소에 성공했습니다",
-                    result = Unit,
-                ),
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "스크랩 취소에 성공했습니다",
+                result = Unit,
             )
+        )
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
@@ -45,7 +45,7 @@ class ScrapServiceTest {
         @Test
         @DisplayName("이미 스크랩한 경우 예외가 발생한다")
         fun scrapFailsIfAlreadyScrapped() {
-            every { scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, announcementId) } returns true
+            every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns true
 
             val exception =
                 assertThrows(ScrapException::class.java) {
@@ -58,7 +58,7 @@ class ScrapServiceTest {
         @Test
         @DisplayName("공고를 찾을 수 없으면 예외가 발생한다")
         fun scrapFailsIfAnnouncementNotFound() {
-            every { scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, announcementId) } returns false
+            every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns false
             every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.empty()
 
             val exception =
@@ -72,7 +72,7 @@ class ScrapServiceTest {
         @Test
         @DisplayName("사용자를 찾을 수 없으면 예외가 발생한다")
         fun scrapFailsIfUserNotFound() {
-            every { scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, announcementId) } returns false
+            every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns false
             every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(mockk())
             every { userRepository.findById(userId) } returns Optional.empty()
 
@@ -91,7 +91,7 @@ class ScrapServiceTest {
             val announcement = mockk<InternshipAnnouncement>(relaxed = true)
             val scrapSlot = slot<Scrap>()
 
-            every { scrapRepository.existsByInternshipAnnouncementIdAndUserId(userId, announcementId) } returns false
+            every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns false
             every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(announcement)
             every { userRepository.findById(userId) } returns Optional.of(user)
             every { scrapRepository.save(capture(scrapSlot)) } returns mockk()
@@ -112,7 +112,7 @@ class ScrapServiceTest {
         @DisplayName("스크랩이 존재하지 않으면 예외가 발생한다")
         fun updateFailsIfScrapNotFound() {
             every {
-                scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, announcementId)
+                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
             } returns null
 
             val exception =
@@ -129,7 +129,7 @@ class ScrapServiceTest {
             val scrap = mockk<Scrap>(relaxed = true)
 
             every {
-                scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, announcementId)
+                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
             } returns scrap
             every { scrap.updateColor(Color.RED) } returns Unit
             every { scrapRepository.save(scrap) } returns scrap
@@ -148,7 +148,7 @@ class ScrapServiceTest {
         @DisplayName("스크랩이 존재하지 않으면 예외가 발생한다")
         fun cancelFailsIfScrapNotFound() {
             every {
-                scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, announcementId)
+                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
             } returns null
 
             val exception =
@@ -165,7 +165,7 @@ class ScrapServiceTest {
             val scrap = mockk<Scrap>()
 
             every {
-                scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, announcementId)
+                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
             } returns scrap
             every {
                 internshipAnnouncementRepository.findById(announcementId)
@@ -186,7 +186,7 @@ class ScrapServiceTest {
             val announcement = mockk<InternshipAnnouncement>(relaxed = true)
 
             every {
-                scrapRepository.findByInternshipAnnouncementIdAndUserId(userId, announcementId)
+                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
             } returns scrap
             every {
                 internshipAnnouncementRepository.findById(announcementId)

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
@@ -81,7 +81,7 @@ class ScrapControllerTest {
         mockMvc.delete("/api/v1/scraps/$internshipAnnouncementId") {
             contentType = MediaType.APPLICATION_JSON
         }.andExpect {
-            status { isNoContent() }
+            status { isOk() }
         }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
@@ -67,6 +68,20 @@ class ScrapControllerTest {
             content = objectMapper.writeValueAsString(scrapUpdateRequest)
         }.andExpect {
             status { isOk() }
+        }
+    }
+
+    @Test
+    @DisplayName("스크랩을 취소한다")
+    fun cancelScrap() {
+        val internshipAnnouncementId = 1L
+        val userId = 1L
+        every { scrapService.cancelScrap(userId, internshipAnnouncementId) } just runs
+
+        mockMvc.delete("/api/v1/scraps/$internshipAnnouncementId") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isNoContent() }
         }
     }
 }


### PR DESCRIPTION
# 📄 Work Description  
- 스크랩 취소 API(`DELETE /api/v1/scraps/{internshipAnnouncementId}`)를 구현했습니다.  
- 유저 ID와 공고 ID를 기반으로 스크랩을 찾아 삭제하며, 스크랩 수 감소 로직도 함께 적용했습니다.  
- 스크랩 또는 공고가 존재하지 않을 경우 각각의 예외 처리를 추가했습니다.  
- 관련된 서비스/컨트롤러/테스트 코드를 모두 작성하여 기능 단위로 검증했습니다.

---

# 💭 Thoughts  
- `스크랩 삭제` 시 `스크랩 수 감소`가 도메인 로직(`InternshipAnnouncement`)에 위임되어 있어 도메인을 구현할 때 객체지향적으로 설계를 잘했다 싶었어요!   
- 서비스 로직에서는 **존재 유무를 먼저 검증한 뒤** 실제 값을 변경하는 흐름으로 구현했는데요,  
  이는 성능 측면에서도 불필요한 DB 조회/연산을 줄일 수 있어 합리적인 순서라고 생각했습니다.  

- 다만 아직 인증이 적용되지 않아 `userId`는 임시로 하드코딩된 상태이며, 이후 `@AuthenticationPrincipal`로 교체가 필요합니다.  
- 그리고 삭제 요청에서도 응답 메시지를 항상 내려주고 있는데, `204 No Content`와 메시지를 함께 내려주는 게 맞는지  
  **응답 일관성 측면에서 유빈님과 함께 논의해보고 싶은 포인트**입니다 😊

---

# ✅ Testing Result  
<img width="376" alt="스크린샷 2025-06-03 오후 8.43.54" src="https://github.com/user-attachments/assets/be67e584-af9d-4585-b6a3-f1eea08f14b4" />

---

# 🗂 Related Issue  
- closed #86
