### PR TITLE
[✨feat] 프로필 정보 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileResponse.kt
@@ -1,10 +1,7 @@
 package com.terning.server.kotlin.application.profile
 
-import com.terning.server.kotlin.domain.auth.vo.AuthType
-import com.terning.server.kotlin.domain.user.vo.ProfileImage
-
 data class ProfileResponse(
     val name: String,
-    val profileImage: ProfileImage,
-    val authType: AuthType,
+    val profileImage: String,
+    val authType: String,
 )

--- a/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileResponse.kt
@@ -1,0 +1,10 @@
+package com.terning.server.kotlin.application.profile
+
+import com.terning.server.kotlin.domain.auth.vo.AuthType
+import com.terning.server.kotlin.domain.user.vo.ProfileImage
+
+data class ProfileResponse(
+    val name: String,
+    val profileImage: ProfileImage,
+    val authType: AuthType,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileService.kt
@@ -3,6 +3,9 @@ package com.terning.server.kotlin.application.profile
 import com.terning.server.kotlin.domain.auth.AuthRepository
 import com.terning.server.kotlin.domain.auth.exception.AuthErrorCode
 import com.terning.server.kotlin.domain.auth.exception.AuthException
+import com.terning.server.kotlin.domain.user.UserRepository
+import com.terning.server.kotlin.domain.user.exception.UserErrorCode
+import com.terning.server.kotlin.domain.user.exception.UserException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -10,19 +13,24 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class ProfileService(
     private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
 ) {
     @Transactional
-    fun getProfile(userId: Long): ProfileResponse {
-        val auth =
-            authRepository.findByUserId(userId)
-                .orElseThrow { AuthException(AuthErrorCode.NOT_FOUND_USER_EXCEPTION) }
+    fun getUserProfile(userId: Long): ProfileResponse {
+        val user =
+            userRepository.findById(userId).orElseThrow {
+                UserException(UserErrorCode.NOT_FOUND_USER_EXCEPTION)
+            }
 
-        val user = auth.user
+        val auth =
+            authRepository.findByUserId(userId).orElseThrow {
+                AuthException(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)
+            }
 
         return ProfileResponse(
             name = user.name(),
-            profileImage = user.profileImage(),
-            authType = auth.authType(),
+            profileImage = user.profileImage().value,
+            authType = auth.authType().value,
         )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileService.kt
@@ -23,7 +23,7 @@ class ProfileService(
             }
 
         val auth =
-            authRepository.findByUserId(userId).orElseThrow {
+            authRepository.findById(userId).orElseThrow {
                 AuthException(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)
             }
 

--- a/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileService.kt
@@ -1,0 +1,28 @@
+package com.terning.server.kotlin.application.profile
+
+import com.terning.server.kotlin.domain.auth.AuthRepository
+import com.terning.server.kotlin.domain.auth.exception.AuthErrorCode
+import com.terning.server.kotlin.domain.auth.exception.AuthException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ProfileService(
+    private val authRepository: AuthRepository,
+) {
+    @Transactional
+    fun getProfile(userId: Long): ProfileResponse {
+        val auth =
+            authRepository.findByUserId(userId)
+                .orElseThrow { AuthException(AuthErrorCode.NOT_FOUND_USER_EXCEPTION) }
+
+        val user = auth.user
+
+        return ProfileResponse(
+            name = user.name(),
+            profileImage = user.profileImage(),
+            authType = auth.authType(),
+        )
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/Auth.kt
@@ -56,6 +56,8 @@ class Auth private constructor(
         }
     }
 
+    fun authType(): AuthType = authType
+
     companion object {
         fun of(
             user: User,

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -1,5 +1,11 @@
 package com.terning.server.kotlin.domain.auth
 
+import com.terning.server.kotlin.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
 
-interface AuthRepository : JpaRepository<Auth, String>
+interface AuthRepository : JpaRepository<Auth, String> {
+    fun user(user: User): MutableList<Auth>
+
+    fun findByUserId(userId: Long): Optional<Auth>
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -1,8 +1,5 @@
 package com.terning.server.kotlin.domain.auth
 
-import com.terning.server.kotlin.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface AuthRepository : JpaRepository<Auth, Long> {
-    fun user(user: User): MutableList<Auth>
-}
+interface AuthRepository : JpaRepository<Auth, Long>

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -2,10 +2,7 @@ package com.terning.server.kotlin.domain.auth
 
 import com.terning.server.kotlin.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.Optional
 
 interface AuthRepository : JpaRepository<Auth, Long> {
     fun user(user: User): MutableList<Auth>
-
-    fun findByUserId(userId: Long): Optional<Auth>
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -4,7 +4,7 @@ import com.terning.server.kotlin.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
 
-interface AuthRepository : JpaRepository<Auth, String> {
+interface AuthRepository : JpaRepository<Auth, Long> {
     fun user(user: User): MutableList<Auth>
 
     fun findByUserId(userId: Long): Optional<Auth>

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -2,7 +2,7 @@ package com.terning.server.kotlin.domain.auth
 
 import com.terning.server.kotlin.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.*
+import java.util.Optional
 
 interface AuthRepository : JpaRepository<Auth, String> {
     fun user(user: User): MutableList<Auth>

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/exception/AuthErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/exception/AuthErrorCode.kt
@@ -7,6 +7,7 @@ enum class AuthErrorCode(
     override val status: HttpStatus,
     override val message: String,
 ) : BaseErrorCode {
+    NOT_FOUND_USER_EXCEPTION(status = HttpStatus.BAD_REQUEST, message = "해당 유저가 존재하지 않습니다"),
     INVALID_TOKEN(status = HttpStatus.UNAUTHORIZED, message = "유효하지 않은 토큰입니다."),
     FAILED_REFRESH_TOKEN_RESET(status = HttpStatus.BAD_REQUEST, message = "리프레시 토큰 초기화에 실패하였습니다"),
     ;

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/vo/AuthType.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/vo/AuthType.kt
@@ -1,6 +1,6 @@
 package com.terning.server.kotlin.domain.auth.vo
 
-enum class AuthType {
-    KAKAO,
-    APPLE,
+enum class AuthType(val value: String) {
+    KAKAO("KAKAO"),
+    APPLE("APPLE"),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/User.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/User.kt
@@ -70,12 +70,11 @@ class User private constructor(
             name: String,
             profile: String,
             userState: UserState = UserState.ACTIVE,
-        ): User {
-            return User(
+        ): User =
+            User(
                 name = UserName.from(name),
                 profileImage = ProfileImage.from(profile),
                 userState = userState,
             )
-        }
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/exception/UserErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/exception/UserErrorCode.kt
@@ -7,5 +7,6 @@ enum class UserErrorCode(
     override val status: HttpStatus,
     override val message: String,
 ) : BaseErrorCode {
+    NOT_FOUND_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 유저가 존재하지 않습니다"),
     INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 프로필 이미지 입니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ProfileController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ProfileController.kt
@@ -1,0 +1,39 @@
+package com.terning.server.kotlin.ui.api
+
+import com.terning.server.kotlin.application.profile.ProfileResponse
+import com.terning.server.kotlin.application.profile.ProfileService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class ProfileController(
+    private val profileService: ProfileService,
+) {
+    @GetMapping("mypage/profile")
+    fun getProfile(
+        // TODO : @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<ProfileResponse>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        val response = profileService.getProfile(userId)
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(
+                ApiResponse.success(
+                    status = HttpStatus.OK,
+                    message = "마이페이지 > 프로필 정보 불러오기를 성공했습니다",
+                    result =
+                        ProfileResponse(
+                            name = response.name,
+                            profileImage = response.profileImage,
+                            authType = response.authType,
+                        ),
+                ),
+            )
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ProfileController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ProfileController.kt
@@ -19,7 +19,7 @@ class ProfileController(
     ): ResponseEntity<ApiResponse<ProfileResponse>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        val response = profileService.getProfile(userId)
+        val response = profileService.getUserProfile(userId)
 
         return ResponseEntity
             .status(HttpStatus.CREATED)
@@ -27,12 +27,7 @@ class ProfileController(
                 ApiResponse.success(
                     status = HttpStatus.OK,
                     message = "마이페이지 > 프로필 정보 불러오기를 성공했습니다",
-                    result =
-                        ProfileResponse(
-                            name = response.name,
-                            profileImage = response.profileImage,
-                            authType = response.authType,
-                        ),
+                    result = response,
                 ),
             )
     }

--- a/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
@@ -9,18 +9,18 @@ import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.RefreshToken
 import com.terning.server.kotlin.domain.user.User
 import com.terning.server.kotlin.domain.user.vo.ProfileImage
+import io.mockk.every
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.BDDMockito.given
-import org.mockito.Mockito.mock
 import java.util.*
 
 class ProfileServiceTest {
 
-    private val authRepository : AuthRepository = mock()
+    private val authRepository: AuthRepository = mockk()
 
     private lateinit var profileService: ProfileService
 
@@ -41,7 +41,8 @@ class ProfileServiceTest {
             refreshToken = RefreshToken("refreshToken")
         )
         val userId = 1L
-        given(authRepository.findByUserId(userId)).willReturn(Optional.of(auth))
+
+        every { authRepository.findByUserId(userId)}  returns Optional.of(auth)
 
         // when
         val result = profileService.getProfile(userId)
@@ -57,7 +58,7 @@ class ProfileServiceTest {
     fun getProfileFailsIfUserNotFound() {
         // given
         val userId = 1L
-        given(authRepository.findByUserId(userId)).willReturn(Optional.empty())
+        every {authRepository.findByUserId(userId)} returns Optional.empty()
 
         // then
         val exception = assertThrows(AuthException::class.java) {

--- a/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
@@ -2,13 +2,13 @@ package com.terning.server.kotlin.application.profile
 
 import com.terning.server.kotlin.domain.auth.Auth
 import com.terning.server.kotlin.domain.auth.AuthRepository
-import com.terning.server.kotlin.domain.auth.exception.AuthErrorCode
-import com.terning.server.kotlin.domain.auth.exception.AuthException
 import com.terning.server.kotlin.domain.auth.vo.AuthId
 import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.RefreshToken
 import com.terning.server.kotlin.domain.user.User
 import com.terning.server.kotlin.domain.user.UserRepository
+import com.terning.server.kotlin.domain.user.exception.UserErrorCode
+import com.terning.server.kotlin.domain.user.exception.UserException
 import com.terning.server.kotlin.domain.user.vo.ProfileImage
 import io.mockk.every
 import io.mockk.mockk
@@ -48,6 +48,7 @@ class ProfileServiceTest {
             )
         val userId = 1L
 
+        every { userRepository.findById(userId) } returns Optional.of(user)
         every { authRepository.findById(userId) } returns Optional.of(auth)
 
         // when
@@ -55,8 +56,8 @@ class ProfileServiceTest {
 
         // then
         assertThat(result.name).isEqualTo("유빈")
-        assertThat(result.profileImage).isEqualTo(ProfileImage.BASIC)
-        assertThat(result.authType).isEqualTo(AuthType.KAKAO)
+        assertThat(result.profileImage).isEqualTo(ProfileImage.BASIC.value)
+        assertThat(result.authType).isEqualTo(AuthType.KAKAO.value)
     }
 
     @Test
@@ -64,14 +65,14 @@ class ProfileServiceTest {
     fun getProfileFailsIfUserNotFound() {
         // given
         val userId = 1L
-        every { authRepository.findById(userId) } returns Optional.empty()
+        every { userRepository.findById(userId) } returns Optional.empty()
 
         // then
         val exception =
-            assertThrows(AuthException::class.java) {
+            assertThrows(UserException::class.java) {
                 profileService.getUserProfile(userId)
             }
 
-        assertThat(exception.errorCode).isEqualTo(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)
+        assertThat(exception.errorCode).isEqualTo(UserErrorCode.NOT_FOUND_USER_EXCEPTION)
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.util.*
+import java.util.Optional
 
 class ProfileServiceTest {
     private val authRepository: AuthRepository = mockk()

--- a/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
@@ -8,6 +8,7 @@ import com.terning.server.kotlin.domain.auth.vo.AuthId
 import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.RefreshToken
 import com.terning.server.kotlin.domain.user.User
+import com.terning.server.kotlin.domain.user.UserRepository
 import com.terning.server.kotlin.domain.user.vo.ProfileImage
 import io.mockk.every
 import io.mockk.mockk
@@ -20,12 +21,17 @@ import java.util.Optional
 
 class ProfileServiceTest {
     private val authRepository: AuthRepository = mockk()
+    private val userRepository: UserRepository = mockk()
 
     private lateinit var profileService: ProfileService
 
     @BeforeEach
     fun setUp() {
-        profileService = ProfileService(authRepository)
+        profileService =
+            ProfileService(
+                authRepository = authRepository,
+                userRepository = userRepository,
+            )
     }
 
     @Test
@@ -42,10 +48,10 @@ class ProfileServiceTest {
             )
         val userId = 1L
 
-        every { authRepository.findByUserId(userId) } returns Optional.of(auth)
+        every { authRepository.findById(userId) } returns Optional.of(auth)
 
         // when
-        val result = profileService.getProfile(userId)
+        val result = profileService.getUserProfile(userId)
 
         // then
         assertThat(result.name).isEqualTo("유빈")
@@ -58,12 +64,12 @@ class ProfileServiceTest {
     fun getProfileFailsIfUserNotFound() {
         // given
         val userId = 1L
-        every { authRepository.findByUserId(userId) } returns Optional.empty()
+        every { authRepository.findById(userId) } returns Optional.empty()
 
         // then
         val exception =
             assertThrows(AuthException::class.java) {
-                profileService.getProfile(userId)
+                profileService.getUserProfile(userId)
             }
 
         assertThat(exception.errorCode).isEqualTo(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)

--- a/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
@@ -1,0 +1,69 @@
+package com.terning.server.kotlin.application.profile
+
+import com.terning.server.kotlin.domain.auth.Auth
+import com.terning.server.kotlin.domain.auth.AuthRepository
+import com.terning.server.kotlin.domain.auth.exception.AuthErrorCode
+import com.terning.server.kotlin.domain.auth.exception.AuthException
+import com.terning.server.kotlin.domain.auth.vo.AuthId
+import com.terning.server.kotlin.domain.auth.vo.AuthType
+import com.terning.server.kotlin.domain.auth.vo.RefreshToken
+import com.terning.server.kotlin.domain.user.User
+import com.terning.server.kotlin.domain.user.vo.ProfileImage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import java.util.*
+
+class ProfileServiceTest {
+
+    private val authRepository : AuthRepository = mock()
+
+    private lateinit var profileService: ProfileService
+
+    @BeforeEach
+    fun setUp() {
+        profileService = ProfileService(authRepository)
+    }
+
+    @Test
+    @DisplayName("userId로 프로필 정보를 성공적으로 조회한다")
+    fun getProfileInformation() {
+        // given
+        val user = User.of(name = "유빈", profile = "BASIC")
+        val auth = Auth.of(
+            user = user,
+            authId = AuthId("123"),
+            authType = AuthType.KAKAO,
+            refreshToken = RefreshToken("refreshToken")
+        )
+        val userId = 1L
+        given(authRepository.findByUserId(userId)).willReturn(Optional.of(auth))
+
+        // when
+        val result = profileService.getProfile(userId)
+
+        // then
+        assertThat(result.name).isEqualTo("유빈")
+        assertThat(result.profileImage).isEqualTo(ProfileImage.BASIC)
+        assertThat(result.authType).isEqualTo(AuthType.KAKAO)
+    }
+
+    @Test
+    @DisplayName("userId로 조회 실패 시 예외를 던진다")
+    fun getProfileFailsIfUserNotFound() {
+        // given
+        val userId = 1L
+        given(authRepository.findByUserId(userId)).willReturn(Optional.empty())
+
+        // then
+        val exception = assertThrows(AuthException::class.java) {
+            profileService.getProfile(userId)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test
 import java.util.*
 
 class ProfileServiceTest {
-
     private val authRepository: AuthRepository = mockk()
 
     private lateinit var profileService: ProfileService
@@ -34,15 +33,16 @@ class ProfileServiceTest {
     fun getProfileInformation() {
         // given
         val user = User.of(name = "유빈", profile = "BASIC")
-        val auth = Auth.of(
-            user = user,
-            authId = AuthId("123"),
-            authType = AuthType.KAKAO,
-            refreshToken = RefreshToken("refreshToken")
-        )
+        val auth =
+            Auth.of(
+                user = user,
+                authId = AuthId("123"),
+                authType = AuthType.KAKAO,
+                refreshToken = RefreshToken("refreshToken"),
+            )
         val userId = 1L
 
-        every { authRepository.findByUserId(userId)}  returns Optional.of(auth)
+        every { authRepository.findByUserId(userId) } returns Optional.of(auth)
 
         // when
         val result = profileService.getProfile(userId)
@@ -58,12 +58,13 @@ class ProfileServiceTest {
     fun getProfileFailsIfUserNotFound() {
         // given
         val userId = 1L
-        every {authRepository.findByUserId(userId)} returns Optional.empty()
+        every { authRepository.findByUserId(userId) } returns Optional.empty()
 
         // then
-        val exception = assertThrows(AuthException::class.java) {
-            profileService.getProfile(userId)
-        }
+        val exception =
+            assertThrows(AuthException::class.java) {
+                profileService.getProfile(userId)
+            }
 
         assertThat(exception.errorCode).isEqualTo(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)
     }


### PR DESCRIPTION
# 📄 Work Description  
- 프로필 정보 API를 구현했습니다.
- `userId`로 Auth를 조회한 후, 해당 인증 정보에 연결된 User 도메인을 통해 프로필 정보를 구성했습니다.
- 관련 유저 정보가 없을 시 예외를 발생하는 `NOT_FOUND_USER_EXCEPTION`도 추가했습니다.

# 💭 Thoughts 
- `application`의 패키징을 어떻게 해야 할지 고민이 되더라구요. 도메인의 경우 터닝 서비스의 특징을 반영해서 `auth`와 `user`처럼 명확히 구분했는데, `application`은 사용자와 직접 맞닿는 영역이다 보니 그 특징을 살려서 `profile`이라고 해두긴 했습니다..! 이에 대해 어떻게 생각하시는지 궁금해요!
- 현재 `ProfileResponse`의 경우 enum 값인 `ProfileImage`, `AuthType`를 리턴하고 있는데요. 이렇게 해도 문제가 없을까요..?
- 테스트 코드는 단순히 get하는 값이기 때문에 성공적으로 리턴하고 있는지, userId로 제대로 조회했는지 여부를 테스트 했는데 혹시 더 확인했으면 하는 점이 있다면 말씀해주세요! 

# ✅ Testing Result  
<img  src ="https://github.com/user-attachments/assets/ff227403-1959-493b-ba4c-ceb88551f24e"  width = 400>


# 🗂 Related Issue  
- closed #81
