### PR TITLE
[✨feat] 프로필 정보 수정 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileRequest.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileRequest.kt
@@ -1,0 +1,6 @@
+package com.terning.server.kotlin.application.profile
+
+data class ProfileRequest(
+    val name: String,
+    val profileImage: String,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/profile/ProfileService.kt
@@ -6,6 +6,8 @@ import com.terning.server.kotlin.domain.auth.exception.AuthException
 import com.terning.server.kotlin.domain.user.UserRepository
 import com.terning.server.kotlin.domain.user.exception.UserErrorCode
 import com.terning.server.kotlin.domain.user.exception.UserException
+import com.terning.server.kotlin.domain.user.vo.ProfileImage
+import com.terning.server.kotlin.domain.user.vo.UserName
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -31,6 +33,25 @@ class ProfileService(
             name = user.name(),
             profileImage = user.profileImage().value,
             authType = auth.authType().value,
+        )
+    }
+
+    @Transactional
+    fun updateUserProfile(
+        userId: Long,
+        profileRequest: ProfileRequest,
+    ) {
+        val user =
+            userRepository.findById(userId).orElseThrow {
+                UserException(UserErrorCode.NOT_FOUND_USER_EXCEPTION)
+            }
+
+        val name = UserName.from(profileRequest.name)
+        val profileImage = ProfileImage.from(profileRequest.profileImage)
+
+        user.updateProfile(
+            newName = name,
+            newProfileImage = profileImage,
         )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -1,4 +1,4 @@
-package com.terning.server.kotlin.application
+package com.terning.server.kotlin.application.scrap
 
 import com.terning.server.kotlin.application.scrap.ScrapRequest
 import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -1,7 +1,5 @@
 package com.terning.server.kotlin.application.scrap
 
-import com.terning.server.kotlin.application.scrap.ScrapRequest
-import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
 import com.terning.server.kotlin.domain.scrap.Scrap
 import com.terning.server.kotlin.domain.scrap.ScrapRepository

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
@@ -22,7 +22,7 @@ class UserName(
         private const val MAX_LENGTH = 12
 
         private const val ERROR_EMPTY = "이름은 공백일 수 없습니다."
-        private const val ERROR_LENGTH = "이름은 $MIN_LENGTH~${MAX_LENGTH}자여야 합니다."
+        const val ERROR_LENGTH = "이름은 $MIN_LENGTH~${MAX_LENGTH}자여야 합니다."
 
         fun from(value: String): UserName = UserName(value)
     }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/vo/UserName.kt
@@ -22,7 +22,7 @@ class UserName(
         private const val MAX_LENGTH = 12
 
         private const val ERROR_EMPTY = "이름은 공백일 수 없습니다."
-        private val ERROR_LENGTH = "이름은 $MIN_LENGTH~${MAX_LENGTH}자여야 합니다."
+        private const val ERROR_LENGTH = "이름은 $MIN_LENGTH~${MAX_LENGTH}자여야 합니다."
 
         fun from(value: String): UserName = UserName(value)
     }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ProfileController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ProfileController.kt
@@ -1,10 +1,13 @@
 package com.terning.server.kotlin.ui.api
 
+import com.terning.server.kotlin.application.profile.ProfileRequest
 import com.terning.server.kotlin.application.profile.ProfileResponse
 import com.terning.server.kotlin.application.profile.ProfileService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -30,5 +33,23 @@ class ProfileController(
                     result = response,
                 ),
             )
+    }
+
+    @PatchMapping("mypage/profile")
+    fun updateProfile(
+        // TODO : @AuthenticationPrincipal userId: Long,
+        @RequestBody profileRequest: ProfileRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        profileService.updateUserProfile()
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "프로필 수정에 성공했습니다",
+                result = Unit,
+            ),
+        )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ProfileController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ProfileController.kt
@@ -42,7 +42,10 @@ class ProfileController(
     ): ResponseEntity<ApiResponse<Unit>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        profileService.updateUserProfile()
+        profileService.updateUserProfile(
+            userId = userId,
+            profileRequest = profileRequest,
+        )
 
         return ResponseEntity.ok(
             ApiResponse.success(

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -1,6 +1,6 @@
 package com.terning.server.kotlin.ui.api
 
-import com.terning.server.kotlin.application.ScrapService
+import com.terning.server.kotlin.application.scrap.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapRequest
 import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -1,7 +1,7 @@
 package com.terning.server.kotlin.ui.api
 
-import com.terning.server.kotlin.application.scrap.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapRequest
+import com.terning.server.kotlin.application.scrap.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
@@ -13,13 +13,13 @@ import com.terning.server.kotlin.domain.user.vo.ProfileImage
 import com.terning.server.kotlin.domain.user.vo.UserName
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.util.Optional
-import io.mockk.verify
 
 class ProfileServiceTest {
     private val authRepository: AuthRepository = mockk()
@@ -113,11 +113,11 @@ class ProfileServiceTest {
         every { userRepository.findById(userId) } returns Optional.of(user)
 
         // then
-        val exception = assertThrows(IllegalArgumentException::class.java) {
-            profileService.updateUserProfile(userId, profileRequest)
-        }
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                profileService.updateUserProfile(userId, profileRequest)
+            }
 
         assertThat(exception.message).contains("이름은 1~12자여야 합니다.")
     }
-
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/profile/ProfileServiceTest.kt
@@ -118,6 +118,6 @@ class ProfileServiceTest {
                 profileService.updateUserProfile(userId, profileRequest)
             }
 
-        assertThat(exception.message).contains("이름은 1~12자여야 합니다.")
+        assertThat(exception.message).contains(UserName.ERROR_LENGTH)
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
@@ -1,7 +1,5 @@
-package com.terning.server.kotlin.application
+package com.terning.server.kotlin.application.scrap
 
-import com.terning.server.kotlin.application.scrap.ScrapRequest
-import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
 import com.terning.server.kotlin.domain.scrap.Scrap

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/profile/ProfileControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/profile/ProfileControllerTest.kt
@@ -7,6 +7,8 @@ import com.terning.server.kotlin.application.profile.ProfileResponse
 import com.terning.server.kotlin.application.profile.ProfileService
 import com.terning.server.kotlin.ui.api.ProfileController
 import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -16,6 +18,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
 
 @WebMvcTest(ProfileController::class)
 @ActiveProfiles("test")
@@ -50,16 +53,41 @@ class ProfileControllerTest {
     @Test
     @DisplayName("유저 정보를 가져온다")
     fun getProfile() {
+        // given
         val userId = 1L
         every { profileService.getUserProfile(userId = userId) } returns profileResponse
 
+        // when
         mockMvc.get("/api/v1/mypage/profile") {
             contentType = MediaType.APPLICATION_JSON
         }.andExpect {
+            // then
             status { isCreated() }
             jsonPath("$.result.name") { value("이유빈") }
             jsonPath("$.result.profileImage") { value("BASIC") }
             jsonPath("$.result.authType") { value("KAKAO") }
+        }
+    }
+
+    @Test
+    @DisplayName("유저 정보를 수정한다")
+    fun updateProfile() {
+        // given
+        val userId = 1L
+        every {
+            profileService.updateUserProfile(
+                userId = userId,
+                profileRequest = profileRequest,
+            )
+        } just runs
+
+        // when
+        mockMvc.patch("/api/v1/mypage/profile") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(profileRequest)
+        }.andExpect {
+            // then
+            status { isOk() }
         }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/profile/ProfileControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/profile/ProfileControllerTest.kt
@@ -1,0 +1,65 @@
+package com.terning.server.kotlin.ui.api.profile
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.terning.server.kotlin.application.profile.ProfileRequest
+import com.terning.server.kotlin.application.profile.ProfileResponse
+import com.terning.server.kotlin.application.profile.ProfileService
+import com.terning.server.kotlin.ui.api.ProfileController
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@WebMvcTest(ProfileController::class)
+@ActiveProfiles("test")
+class ProfileControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var profileService: ProfileService
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var profileResponse: ProfileResponse
+    private lateinit var profileRequest: ProfileRequest
+
+    @BeforeEach
+    fun setUp() {
+        profileResponse =
+            ProfileResponse(
+                name = "이유빈",
+                profileImage = "BASIC",
+                authType = "KAKAO",
+            )
+        profileRequest =
+            ProfileRequest(
+                name = "이유빈 수정",
+                profileImage = "LUCKY",
+            )
+    }
+
+    @Test
+    @DisplayName("유저 정보를 가져온다")
+    fun getProfile() {
+        val userId = 1L
+        every { profileService.getUserProfile(userId = userId) } returns profileResponse
+
+        mockMvc.get("/api/v1/mypage/profile") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.result.name") { value("이유빈") }
+            jsonPath("$.result.profileImage") { value("BASIC") }
+            jsonPath("$.result.authType") { value("KAKAO") }
+        }
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
@@ -1,10 +1,11 @@
-package com.terning.server.kotlin.ui.api
+package com.terning.server.kotlin.ui.api.scrap
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.terning.server.kotlin.application.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapRequest
 import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
+import com.terning.server.kotlin.ui.api.ScrapController
 import io.mockk.every
 import io.mockk.just
 import io.mockk.runs

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
@@ -2,7 +2,7 @@ package com.terning.server.kotlin.ui.api.scrap
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
-import com.terning.server.kotlin.application.ScrapService
+import com.terning.server.kotlin.application.scrap.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapRequest
 import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import com.terning.server.kotlin.ui.api.ScrapController

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
@@ -2,8 +2,8 @@ package com.terning.server.kotlin.ui.api.scrap
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
-import com.terning.server.kotlin.application.scrap.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapRequest
+import com.terning.server.kotlin.application.scrap.ScrapService
 import com.terning.server.kotlin.application.scrap.ScrapUpdateRequest
 import com.terning.server.kotlin.ui.api.ScrapController
 import io.mockk.every


### PR DESCRIPTION
# 📄 Work Description  
- `프로필 정보 수정` API를 구현하였습니다.
- 지난번 `프로필 정보` API를 구현할 때 Controller 쪽 테스트 코드를 작성하지 않아 이번 PR에서 함께 작성해 주었습니다.
- scrap 쪽 부분 패키지 정리해야 될 부분이 있어서 같이 해 주었어요!

# 💭 Thoughts 
- JPA의 더티체킹 기능 관련해서 지난번에 이야기를 나눠보았을 때 이 기능을 활용하여 별도로 저장하는 코드는 작성하지 않기로 했었는데요. 그에 따라 이번에도 update하는 코드를 작성해 준 후, 별다른 조치는 하지 않았습니다! 

# ✅ Testing Result  
<img width="379" alt="image" src="https://github.com/user-attachments/assets/a295d1ca-1ac5-43ed-b210-23264183202b" />
<img width="390" alt="image" src="https://github.com/user-attachments/assets/fa21b037-61fb-4e38-95c3-31eefb58b135" />

# 🗂 Related Issue  
- closed #89 
