### PR TITLE
[✨feat] 월간 캘린더(디테일) API구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterResponse.kt
@@ -1,6 +1,6 @@
 package com.terning.server.kotlin.application.filter
 
-data class FilterResponse (
+data class FilterResponse(
     val jobType: String,
     val grade: String,
     val workingPeriod: String,

--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterResponse.kt
@@ -1,6 +1,6 @@
-package com.terning.server.kotlin.application.filtering
+package com.terning.server.kotlin.application.filter
 
-data class FilteringResponse (
+data class FilterResponse (
     val jobType: String,
     val grade: String,
     val workingPeriod: String,

--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
@@ -1,8 +1,8 @@
 package com.terning.server.kotlin.application.filter
 
 import com.terning.server.kotlin.domain.filter.FilterRepository
-import com.terning.server.kotlin.domain.user.exception.UserErrorCode
-import com.terning.server.kotlin.domain.user.exception.UserException
+import com.terning.server.kotlin.domain.filter.exception.FilterErrorCode
+import com.terning.server.kotlin.domain.filter.exception.FilterException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,7 +15,7 @@ class FilterService(
     fun getUserFilter(userId: Long): FilterResponse {
         val filter =
             filterRepository.findById(userId).orElseThrow {
-                UserException(UserErrorCode.NOT_FOUND_USER_EXCEPTION)
+                FilterException(FilterErrorCode.NOT_FOUND_USER_EXCEPTION)
             }
 
         return FilterResponse(

--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
@@ -1,0 +1,29 @@
+package com.terning.server.kotlin.application.filter
+
+import com.terning.server.kotlin.domain.filter.FilterRepository
+import com.terning.server.kotlin.domain.user.exception.UserErrorCode
+import com.terning.server.kotlin.domain.user.exception.UserException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class FilterService(
+    private val filterRepository: FilterRepository,
+) {
+    @Transactional
+    fun getUserFilter(userId: Long): FilterResponse {
+        val filter =
+            filterRepository.findById(userId).orElseThrow {
+                UserException(UserErrorCode.NOT_FOUND_USER_EXCEPTION)
+            }
+
+        return FilterResponse(
+            jobType = filter.jobType().type,
+            grade = filter.grade().type,
+            workingPeriod = filter.workingPeriod().period,
+            startYear = filter.startDate().filterYear.value,
+            startMonth = filter.startDate().filterMonth.value,
+        )
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
@@ -18,12 +18,14 @@ class FilterService(
                 FilterException(FilterErrorCode.NOT_FOUND_USER_EXCEPTION)
             }
 
+        val startDate = filter.startDate()
+
         return FilterResponse(
             jobType = filter.jobType().type,
             grade = filter.grade().type,
             workingPeriod = filter.workingPeriod().period,
-            startYear = filter.startDate().filterYear.value,
-            startMonth = filter.startDate().filterMonth.value,
+            startYear = startDate.filterYear.value,
+            startMonth = startDate.filterMonth.value,
         )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/filtering/FilteringResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filtering/FilteringResponse.kt
@@ -1,0 +1,9 @@
+package com.terning.server.kotlin.application.filtering
+
+data class FilteringResponse (
+    val jobType: String,
+    val grade: String,
+    val workingPeriod: String,
+    val startYear: Int,
+    val startMonth: Int,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -17,6 +17,7 @@ import com.terning.server.kotlin.domain.scrap.vo.Color
 import com.terning.server.kotlin.domain.user.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.LocalDate
 
 @Service
@@ -25,6 +26,7 @@ class ScrapService(
     private val scrapRepository: ScrapRepository,
     private val userRepository: UserRepository,
     private val internshipAnnouncementRepository: InternshipAnnouncementRepository,
+    private val clock: Clock,
 ) {
     @Transactional
     fun scrap(
@@ -148,8 +150,7 @@ class ScrapService(
                         scraps =
                             dailyScraps.map { scrap ->
                                 val announcement = scrap.internshipAnnouncement
-
-                                DetailedScrap(
+                                DetailedScrap.from(
                                     announcementId =
                                         announcement.id
                                             ?: throw ScrapException(ScrapErrorCode.SCRAP_ID_NULL),
@@ -161,6 +162,7 @@ class ScrapService(
                                     deadline = deadline,
                                     startYear = announcement.startDate.year.value,
                                     startMonth = announcement.startDate.month.value,
+                                    clock = clock,
                                 )
                             },
                     )

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/dto/DetailedMonthlyScrapResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/dto/DetailedMonthlyScrapResponse.kt
@@ -1,0 +1,40 @@
+package com.terning.server.kotlin.application.scrap.dto
+
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+data class DetailedMonthlyScrapResponse(
+    val dailyGroups: List<DetailedScrapGroup>,
+)
+
+data class DetailedScrapGroup(
+    val deadline: String,
+    val scraps: List<DetailedScrap>,
+)
+
+data class DetailedScrap(
+    val announcementId: Long,
+    val companyImageUrl: String,
+    val title: String,
+    val workingPeriod: String,
+    val isScrapped: Boolean,
+    val hexColor: String,
+    val deadline: LocalDate,
+    val startYear: Int,
+    val startMonth: Int,
+) {
+    val formattedDeadline: String = formatToDday(deadline)
+    val deadlineText: String = "${deadline.year}년 ${deadline.monthValue}월 ${deadline.dayOfMonth}일"
+    val startYearMonth: String = "${startYear}년 ${startMonth}월"
+
+    companion object {
+        private fun formatToDday(deadline: LocalDate): String {
+            val today = LocalDate.now()
+            return when {
+                deadline.isEqual(today) -> "D-DAY"
+                deadline.isBefore(today) -> "지원마감"
+                else -> "D-${ChronoUnit.DAYS.between(today, deadline)}"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/dto/DetailedMonthlyScrapResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/dto/DetailedMonthlyScrapResponse.kt
@@ -22,19 +22,44 @@ data class DetailedScrap(
     val deadline: LocalDate,
     val startYear: Int,
     val startMonth: Int,
+    val formattedDeadline: String,
 ) {
-    val formattedDeadline: String = formatToDday(deadline)
     val deadlineText: String = "${deadline.year}년 ${deadline.monthValue}월 ${deadline.dayOfMonth}일"
     val startYearMonth: String = "${startYear}년 ${startMonth}월"
 
     companion object {
-        private fun formatToDday(deadline: LocalDate): String {
-            val today = LocalDate.now()
-            return when {
-                deadline.isEqual(today) -> "D-DAY"
-                deadline.isBefore(today) -> "지원마감"
-                else -> "D-${ChronoUnit.DAYS.between(today, deadline)}"
-            }
+        fun from(
+            announcementId: Long,
+            companyImageUrl: String,
+            title: String,
+            workingPeriod: String,
+            isScrapped: Boolean,
+            hexColor: String,
+            deadline: LocalDate,
+            startYear: Int,
+            startMonth: Int,
+            clock: java.time.Clock,
+        ): DetailedScrap {
+            val today = LocalDate.now(clock)
+            val formattedDeadline =
+                when {
+                    deadline.isEqual(today) -> "D-DAY"
+                    deadline.isBefore(today) -> "지원마감"
+                    else -> "D-${ChronoUnit.DAYS.between(today, deadline)}"
+                }
+
+            return DetailedScrap(
+                announcementId,
+                companyImageUrl,
+                title,
+                workingPeriod,
+                isScrapped,
+                hexColor,
+                deadline,
+                startYear,
+                startMonth,
+                formattedDeadline,
+            )
         }
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/dto/DetailedMonthlyScrapResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/dto/DetailedMonthlyScrapResponse.kt
@@ -1,5 +1,7 @@
 package com.terning.server.kotlin.application.scrap.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import java.time.Clock
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -12,20 +14,30 @@ data class DetailedScrapGroup(
     val scraps: List<DetailedScrap>,
 )
 
-data class DetailedScrap(
-    val announcementId: Long,
-    val companyImageUrl: String,
-    val title: String,
-    val workingPeriod: String,
-    val isScrapped: Boolean,
-    val hexColor: String,
-    val deadline: LocalDate,
-    val startYear: Int,
-    val startMonth: Int,
-    val formattedDeadline: String,
+data class DetailedScrap private constructor(
+    private val rawAnnouncementId: Long,
+    private val rawCompanyImageUrl: String,
+    private val rawTitle: String,
+    private val rawWorkingPeriod: String,
+    private val rawIsScrapped: Boolean,
+    private val rawHexColor: String,
+    @get:JsonIgnore
+    private val rawDeadline: LocalDate,
+    @get:JsonIgnore
+    private val rawStartYear: Int,
+    @get:JsonIgnore
+    private val rawStartMonth: Int,
+    private val rawDDay: String,
 ) {
-    val deadlineText: String = "${deadline.year}년 ${deadline.monthValue}월 ${deadline.dayOfMonth}일"
-    val startYearMonth: String = "${startYear}년 ${startMonth}월"
+    val internshipAnnouncementId: Long = rawAnnouncementId
+    val companyImage: String = rawCompanyImageUrl
+    val dDay: String = rawDDay
+    val title: String = rawTitle
+    val workingPeriod: String = rawWorkingPeriod
+    val isScrapped: Boolean = rawIsScrapped
+    val color: String = rawHexColor
+    val deadline: String = "${rawDeadline.year}년 ${rawDeadline.monthValue}월 ${rawDeadline.dayOfMonth}일"
+    val startYearMonth: String = "${rawStartYear}년 ${rawStartMonth}월"
 
     companion object {
         fun from(
@@ -38,10 +50,10 @@ data class DetailedScrap(
             deadline: LocalDate,
             startYear: Int,
             startMonth: Int,
-            clock: java.time.Clock,
+            clock: Clock,
         ): DetailedScrap {
             val today = LocalDate.now(clock)
-            val formattedDeadline =
+            val dDay =
                 when {
                     deadline.isEqual(today) -> "D-DAY"
                     deadline.isBefore(today) -> "지원마감"
@@ -49,16 +61,16 @@ data class DetailedScrap(
                 }
 
             return DetailedScrap(
-                announcementId,
-                companyImageUrl,
-                title,
-                workingPeriod,
-                isScrapped,
-                hexColor,
-                deadline,
-                startYear,
-                startMonth,
-                formattedDeadline,
+                rawAnnouncementId = announcementId,
+                rawCompanyImageUrl = companyImageUrl,
+                rawTitle = title,
+                rawWorkingPeriod = workingPeriod,
+                rawIsScrapped = isScrapped,
+                rawHexColor = hexColor,
+                rawDeadline = deadline,
+                rawStartYear = startYear,
+                rawStartMonth = startMonth,
+                rawDDay = dDay,
             )
         }
     }

--- a/src/main/kotlin/com/terning/server/kotlin/config/ClockConfig.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/config/ClockConfig.kt
@@ -1,0 +1,11 @@
+package com.terning.server.kotlin.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class ClockConfig {
+    @Bean
+    fun clock(): Clock = Clock.systemDefaultZone()
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/FilterRepository.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.domain.filter
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FilterRepository : JpaRepository<Filter, Long>

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/exception/FilterErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/exception/FilterErrorCode.kt
@@ -7,6 +7,7 @@ enum class FilterErrorCode(
     override val status: HttpStatus,
     override val message: String,
 ) : BaseErrorCode {
+    NOT_FOUND_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 유저가 존재하지 않습니다"),
     INVALID_WORKING_PERIOD(HttpStatus.BAD_REQUEST, "유효하지 않은 근무 기간입니다."),
     INVALID_GRADE(HttpStatus.BAD_REQUEST, "유효하지 않은 학년입니다."),
     INVALID_YEAR(HttpStatus.BAD_REQUEST, "연도는 1900보다 커야 합니다."),

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
@@ -1,0 +1,32 @@
+package com.terning.server.kotlin.ui.api
+
+import com.terning.server.kotlin.application.filter.FilterResponse
+import com.terning.server.kotlin.application.filter.FilterService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class FilterController(
+    private val filterService: FilterService,
+) {
+    @GetMapping("filters")
+    fun getUserFilter(
+        // TODO : @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<FilterResponse>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        val response = filterService.getUserFilter(userId)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "사용자의 필터링 정보를 불러오는데 성공했습니다",
+                result = response,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -30,11 +30,12 @@ class ScrapController(
     ): ResponseEntity<ApiResponse<DetailedMonthlyScrapResponse>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        val response = scrapService.detailedMonthlyScraps(
-            userId = userId,
-            year = year,
-            month = month,
-        )
+        val response =
+            scrapService.detailedMonthlyScraps(
+                userId = userId,
+                year = year,
+                month = month,
+            )
 
         return ResponseEntity.ok(
             ApiResponse.success(
@@ -53,11 +54,12 @@ class ScrapController(
     ): ResponseEntity<ApiResponse<MonthlyScrapDeadlineResponse>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        val monthlyScrapDeadlineResponse = scrapService.monthlyScrapDeadlines(
-            userId = userId,
-            year = year,
-            month = month,
-        )
+        val monthlyScrapDeadlineResponse =
+            scrapService.monthlyScrapDeadlines(
+                userId = userId,
+                year = year,
+                month = month,
+            )
 
         return ResponseEntity.ok(
             ApiResponse.success(

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -1,6 +1,7 @@
 package com.terning.server.kotlin.ui.api
 
 import com.terning.server.kotlin.application.ScrapService
+import com.terning.server.kotlin.application.scrap.dto.DetailedMonthlyScrapResponse
 import com.terning.server.kotlin.application.scrap.dto.MonthlyScrapDeadlineResponse
 import com.terning.server.kotlin.application.scrap.dto.ScrapRequest
 import com.terning.server.kotlin.application.scrap.dto.ScrapUpdateRequest
@@ -21,6 +22,25 @@ import org.springframework.web.bind.annotation.RestController
 class ScrapController(
     private val scrapService: ScrapService,
 ) {
+    @GetMapping("/calendar/monthly-list")
+    fun monthlyScrapsAsList(
+        // TODO: @AuthenticationPrincipal userId: Long,
+        @RequestParam("year") year: Int,
+        @RequestParam("month") month: Int,
+    ): ResponseEntity<ApiResponse<DetailedMonthlyScrapResponse>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        val response = scrapService.detailedMonthlyScraps(userId, year, month)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "캘린더 > (월간) 스크랩 된 공고 정보 (리스트) 불러오기를 성공했습니다",
+                result = response,
+            ),
+        )
+    }
+
     @GetMapping("/calendar/monthly-default")
     fun monthlyScraps(
         // TODO: @AuthenticationPrincipal userId: Long,

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -30,7 +30,11 @@ class ScrapController(
     ): ResponseEntity<ApiResponse<DetailedMonthlyScrapResponse>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        val response = scrapService.detailedMonthlyScraps(userId, year, month)
+        val response = scrapService.detailedMonthlyScraps(
+            userId = userId,
+            year = year,
+            month = month,
+        )
 
         return ResponseEntity.ok(
             ApiResponse.success(
@@ -49,7 +53,11 @@ class ScrapController(
     ): ResponseEntity<ApiResponse<MonthlyScrapDeadlineResponse>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        val monthlyScrapDeadlineResponse = scrapService.monthlyScrapDeadlines(userId, year, month)
+        val monthlyScrapDeadlineResponse = scrapService.monthlyScrapDeadlines(
+            userId = userId,
+            year = year,
+            month = month,
+        )
 
         return ResponseEntity.ok(
             ApiResponse.success(
@@ -68,7 +76,11 @@ class ScrapController(
     ): ResponseEntity<ApiResponse<Unit>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        scrapService.scrap(userId, internshipAnnouncementId, scrapRequest)
+        scrapService.scrap(
+            userId = userId,
+            internshipAnnouncementId = internshipAnnouncementId,
+            scrapRequest = scrapRequest,
+        )
 
         return ResponseEntity
             .status(HttpStatus.CREATED)
@@ -89,7 +101,11 @@ class ScrapController(
     ): ResponseEntity<ApiResponse<Unit>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        scrapService.updateScrap(userId, internshipAnnouncementId, scrapUpdateRequest)
+        scrapService.updateScrap(
+            userId = userId,
+            internshipAnnouncementId = internshipAnnouncementId,
+            scrapUpdateRequest = scrapUpdateRequest,
+        )
 
         return ResponseEntity
             .status(HttpStatus.OK)
@@ -109,7 +125,10 @@ class ScrapController(
     ): ResponseEntity<ApiResponse<Unit>> {
         val userId: Long = 1 // 임시 userId
 
-        scrapService.cancelScrap(userId, internshipAnnouncementId)
+        scrapService.cancelScrap(
+            userId = userId,
+            internshipAnnouncementId = internshipAnnouncementId,
+        )
 
         return ResponseEntity.ok(
             ApiResponse.success(

--- a/src/test/kotlin/com/terning/server/kotlin/application/filter/FilterServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/filter/FilterServiceTest.kt
@@ -1,0 +1,72 @@
+package com.terning.server.kotlin.application.filter
+
+import com.terning.server.kotlin.domain.filter.Filter
+import com.terning.server.kotlin.domain.filter.FilterRepository
+import com.terning.server.kotlin.domain.filter.vo.*
+import com.terning.server.kotlin.domain.user.exception.UserErrorCode
+import com.terning.server.kotlin.domain.user.exception.UserException
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+class FilterServiceTest {
+    private val filterRepository: FilterRepository = mockk()
+
+    private lateinit var filterService: FilterService
+
+    @BeforeEach
+    fun setUp() {
+        filterService = FilterService(filterRepository = filterRepository)
+    }
+
+    @Test
+    @DisplayName("사용자를 찾을 수 없으면 에러가 발생한다")
+    fun getFilterFailsIfUserNotFound() {
+        // given
+        val userId = 1L
+        every { filterRepository.findById(userId) } returns Optional.empty()
+
+        // then
+        val exception =
+            assertThrows(UserException::class.java) {
+                filterService.getUserFilter(userId)
+            }
+
+        assertThat(exception.errorCode).isEqualTo(UserErrorCode.NOT_FOUND_USER_EXCEPTION)
+    }
+
+    @Test
+    @DisplayName("필터 정보를 성공적으로 조회한다")
+    fun getFilterInformation() {
+        // given
+        val userId = 1L
+        val filter =
+            Filter.of(
+                filterJobType = FilterJobType.IT,
+                filterGrade = FilterGrade.SENIOR,
+                filterWorkingPeriod = FilterWorkingPeriod.SHORT_TERM,
+                filterStartDate =
+                    FilterStartDate.of(
+                        filterYear = FilterYear.from(2025),
+                        filterMonth = FilterMonth.from(6),
+                    ),
+            )
+
+        every { filterRepository.findById(userId) } returns Optional.of(filter)
+
+        // when
+        val result = filterService.getUserFilter(userId)
+
+        // then
+        assertThat(result.jobType).isEqualTo("it")
+        assertThat(result.grade).isEqualTo("senior")
+        assertThat(result.workingPeriod).isEqualTo("short")
+        assertThat(result.startYear).isEqualTo(2025)
+        assertThat(result.startMonth).isEqualTo(6)
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/application/filter/FilterServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/filter/FilterServiceTest.kt
@@ -2,7 +2,12 @@ package com.terning.server.kotlin.application.filter
 
 import com.terning.server.kotlin.domain.filter.Filter
 import com.terning.server.kotlin.domain.filter.FilterRepository
-import com.terning.server.kotlin.domain.filter.vo.*
+import com.terning.server.kotlin.domain.filter.vo.FilterGrade
+import com.terning.server.kotlin.domain.filter.vo.FilterJobType
+import com.terning.server.kotlin.domain.filter.vo.FilterMonth
+import com.terning.server.kotlin.domain.filter.vo.FilterStartDate
+import com.terning.server.kotlin.domain.filter.vo.FilterWorkingPeriod
+import com.terning.server.kotlin.domain.filter.vo.FilterYear
 import com.terning.server.kotlin.domain.user.exception.UserErrorCode
 import com.terning.server.kotlin.domain.user.exception.UserException
 import io.mockk.every

--- a/src/test/kotlin/com/terning/server/kotlin/application/filter/FilterServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/filter/FilterServiceTest.kt
@@ -2,14 +2,14 @@ package com.terning.server.kotlin.application.filter
 
 import com.terning.server.kotlin.domain.filter.Filter
 import com.terning.server.kotlin.domain.filter.FilterRepository
+import com.terning.server.kotlin.domain.filter.exception.FilterErrorCode
+import com.terning.server.kotlin.domain.filter.exception.FilterException
 import com.terning.server.kotlin.domain.filter.vo.FilterGrade
 import com.terning.server.kotlin.domain.filter.vo.FilterJobType
 import com.terning.server.kotlin.domain.filter.vo.FilterMonth
 import com.terning.server.kotlin.domain.filter.vo.FilterStartDate
 import com.terning.server.kotlin.domain.filter.vo.FilterWorkingPeriod
 import com.terning.server.kotlin.domain.filter.vo.FilterYear
-import com.terning.server.kotlin.domain.user.exception.UserErrorCode
-import com.terning.server.kotlin.domain.user.exception.UserException
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -38,11 +38,11 @@ class FilterServiceTest {
 
         // then
         val exception =
-            assertThrows(UserException::class.java) {
+            assertThrows(FilterException::class.java) {
                 filterService.getUserFilter(userId)
             }
 
-        assertThat(exception.errorCode).isEqualTo(UserErrorCode.NOT_FOUND_USER_EXCEPTION)
+        assertThat(exception.errorCode).isEqualTo(FilterErrorCode.NOT_FOUND_USER_EXCEPTION)
     }
 
     @Test

--- a/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
@@ -4,8 +4,6 @@ import com.terning.server.kotlin.application.scrap.dto.ScrapRequest
 import com.terning.server.kotlin.application.scrap.dto.ScrapUpdateRequest
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
-import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnnouncementDeadline
-import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipTitle
 import com.terning.server.kotlin.domain.scrap.Scrap
 import com.terning.server.kotlin.domain.scrap.ScrapRepository
 import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
@@ -14,28 +12,27 @@ import com.terning.server.kotlin.domain.scrap.vo.Color
 import com.terning.server.kotlin.domain.user.User
 import com.terning.server.kotlin.domain.user.UserRepository
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Clock
 import java.time.Instant
-import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Optional
 
 class ScrapServiceTest {
-    private val scrapRepository: ScrapRepository = mockk()
-    private val userRepository: UserRepository = mockk()
-    private val internshipAnnouncementRepository: InternshipAnnouncementRepository = mockk()
-
+    private val scrapRepository: ScrapRepository = mockk(relaxed = true)
+    private val userRepository: UserRepository = mockk(relaxed = true)
+    private val internshipAnnouncementRepository: InternshipAnnouncementRepository = mockk(relaxed = true)
     private lateinit var scrapService: ScrapService
-    private lateinit var clock: Clock
 
     private val userId = 1L
     private val announcementId = 100L
@@ -43,7 +40,7 @@ class ScrapServiceTest {
 
     @BeforeEach
     fun setUp() {
-        clock = Clock.fixed(Instant.parse("2025-06-08T00:00:00Z"), ZoneId.systemDefault())
+        val clock = Clock.fixed(Instant.parse("2025-06-08T00:00:00Z"), ZoneId.systemDefault())
         scrapService = ScrapService(scrapRepository, userRepository, internshipAnnouncementRepository, clock)
     }
 
@@ -53,59 +50,55 @@ class ScrapServiceTest {
         @Test
         @DisplayName("이미 스크랩한 경우 예외가 발생한다")
         fun scrapFailsIfAlreadyScrapped() {
-            every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns true
+            // given
+            givenScrapExists()
 
-            val exception =
-                assertThrows(ScrapException::class.java) {
-                    scrapService.scrap(userId, announcementId, request)
-                }
-
+            // when & then
+            val exception = assertThrows<ScrapException> { scrapService.scrap(userId, announcementId, request) }
             assertEquals(ScrapErrorCode.EXISTS_SCRAP_ALREADY, exception.errorCode)
         }
 
         @Test
         @DisplayName("공고를 찾을 수 없으면 예외가 발생한다")
         fun scrapFailsIfAnnouncementNotFound() {
-            every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns false
+            // given
+            givenScrapDoesNotExist()
             every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.empty()
 
-            val exception =
-                assertThrows(ScrapException::class.java) {
-                    scrapService.scrap(userId, announcementId, request)
-                }
-
+            // when & then
+            val exception = assertThrows<ScrapException> { scrapService.scrap(userId, announcementId, request) }
             assertEquals(ScrapErrorCode.INTERN_SHIP_ANNOUNCEMENT_NOT_FOUND, exception.errorCode)
         }
 
         @Test
         @DisplayName("사용자를 찾을 수 없으면 예외가 발생한다")
         fun scrapFailsIfUserNotFound() {
-            every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns false
-            every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(mockk())
+            // given
+            givenScrapDoesNotExist()
+            givenAnnouncementExists(mockk())
             every { userRepository.findById(userId) } returns Optional.empty()
 
-            val exception =
-                assertThrows(ScrapException::class.java) {
-                    scrapService.scrap(userId, announcementId, request)
-                }
-
+            // when & then
+            val exception = assertThrows<ScrapException> { scrapService.scrap(userId, announcementId, request) }
             assertEquals(ScrapErrorCode.USER_NOT_FOUND, exception.errorCode)
         }
 
         @Test
         @DisplayName("스크랩에 성공한다")
         fun scrapSucceeds() {
+            // given
             val user = mockk<User>()
             val announcement = mockk<InternshipAnnouncement>(relaxed = true)
             val scrapSlot = slot<Scrap>()
 
-            every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns false
-            every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(announcement)
-            every { userRepository.findById(userId) } returns Optional.of(user)
+            givenScrapDoesNotExist()
+            givenUserAndAnnouncementExist(user, announcement)
             every { scrapRepository.save(capture(scrapSlot)) } returns mockk()
 
+            // when
             scrapService.scrap(userId, announcementId, request)
 
+            // then
             verify { announcement.increaseScrapCount() }
             assertEquals(Color.BLUE.toHexString(), scrapSlot.captured.hexColor())
         }
@@ -115,35 +108,32 @@ class ScrapServiceTest {
     @DisplayName("스크랩 색상 변경")
     inner class UpdateScrapTest {
         private val updateRequest = ScrapUpdateRequest(color = "RED")
+        private val scrap = mockk<Scrap>(relaxed = true)
 
         @Test
         @DisplayName("스크랩이 존재하지 않으면 예외가 발생한다")
         fun updateFailsIfScrapNotFound() {
-            every {
-                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
-            } returns null
+            // given
+            every { scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns null
 
-            val exception =
-                assertThrows(ScrapException::class.java) {
-                    scrapService.updateScrap(userId, announcementId, updateRequest)
-                }
-
+            // when & then
+            val exception = assertThrows<ScrapException> { scrapService.updateScrap(userId, announcementId, updateRequest) }
             assertEquals(ScrapErrorCode.SCRAP_NOT_FOUND, exception.errorCode)
         }
 
         @Test
         @DisplayName("스크랩 색상을 성공적으로 업데이트한다")
         fun updateSucceeds() {
-            val scrap = mockk<Scrap>(relaxed = true)
-
-            every {
-                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
-            } returns scrap
-            every { scrap.updateColor(Color.RED) } returns Unit
+            // given
+            every { scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns scrap
+            every { scrap.updateColor(Color.RED) } just runs
+            // [수정] 누락되었던 save() mocking 추가
             every { scrapRepository.save(scrap) } returns scrap
 
+            // when
             scrapService.updateScrap(userId, announcementId, updateRequest)
 
+            // then
             verify { scrap.updateColor(Color.RED) }
             verify { scrapRepository.save(scrap) }
         }
@@ -152,206 +142,63 @@ class ScrapServiceTest {
     @Nested
     @DisplayName("스크랩 취소")
     inner class CancelScrapTest {
+        private val scrap = mockk<Scrap>()
+        private val announcement = mockk<InternshipAnnouncement>(relaxed = true)
+
         @Test
         @DisplayName("스크랩이 존재하지 않으면 예외가 발생한다")
         fun cancelFailsIfScrapNotFound() {
-            every {
-                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
-            } returns null
+            // given
+            every { scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns null
 
-            val exception =
-                assertThrows(ScrapException::class.java) {
-                    scrapService.cancelScrap(userId, announcementId)
-                }
-
+            // when & then
+            val exception = assertThrows<ScrapException> { scrapService.cancelScrap(userId, announcementId) }
             assertEquals(ScrapErrorCode.SCRAP_NOT_FOUND, exception.errorCode)
         }
 
         @Test
         @DisplayName("공고가 존재하지 않으면 예외가 발생한다")
         fun cancelFailsIfAnnouncementNotFound() {
-            val scrap = mockk<Scrap>()
+            // given
+            every { scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns scrap
+            every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.empty()
 
-            every {
-                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
-            } returns scrap
-            every {
-                internshipAnnouncementRepository.findById(announcementId)
-            } returns Optional.empty()
-
-            val exception =
-                assertThrows(ScrapException::class.java) {
-                    scrapService.cancelScrap(userId, announcementId)
-                }
-
+            // when & then
+            val exception = assertThrows<ScrapException> { scrapService.cancelScrap(userId, announcementId) }
             assertEquals(ScrapErrorCode.INTERN_SHIP_ANNOUNCEMENT_NOT_FOUND, exception.errorCode)
         }
 
         @Test
         @DisplayName("스크랩 취소에 성공한다")
         fun cancelSucceeds() {
-            val scrap = mockk<Scrap>()
-            val announcement = mockk<InternshipAnnouncement>(relaxed = true)
+            // given
+            every { scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns scrap
+            every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(announcement)
+            every { scrapRepository.delete(scrap) } just runs
 
-            every {
-                scrapRepository.findByUserIdAndInternshipAnnouncementId(userId, announcementId)
-            } returns scrap
-            every {
-                internshipAnnouncementRepository.findById(announcementId)
-            } returns Optional.of(announcement)
-            every { scrapRepository.delete(scrap) } returns Unit
-
+            // when
             scrapService.cancelScrap(userId, announcementId)
 
+            // then
             verify { announcement.decreaseScrapCount() }
             verify { scrapRepository.delete(scrap) }
         }
     }
 
-    @Nested
-    @DisplayName("월간 스크랩 마감일 조회")
-    inner class MonthlyScrapDeadlineTest {
-        @Test
-        @DisplayName("마감일 기준으로 그룹핑된 스크랩을 반환한다")
-        fun returnsGroupedScrapsByDeadline() {
-            val deadline = LocalDate.of(2025, 6, 30)
-            val scrapId = 1L
-
-            val title = mockk<InternshipTitle>()
-            every { title.value } returns "테스트 공고"
-
-            val internshipAnnouncementDeadline =
-                mockk<InternshipAnnouncementDeadline>()
-            every { internshipAnnouncementDeadline.value } returns deadline
-
-            val internshipAnnouncement = mockk<InternshipAnnouncement>()
-            every { internshipAnnouncement.title } returns title
-            every { internshipAnnouncement.internshipAnnouncementDeadline } returns internshipAnnouncementDeadline
-
-            val scrap = mockk<Scrap>()
-            every { scrap.id } returns scrapId
-            every { scrap.internshipAnnouncement } returns internshipAnnouncement
-            every { scrap.hexColor() } returns "#4AA9F2"
-
-            every {
-                scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(
-                    userId = userId,
-                    start = LocalDate.of(2025, 6, 1),
-                    end = LocalDate.of(2025, 6, 30),
-                )
-            } returns listOf(scrap)
-
-            val response = scrapService.monthlyScrapDeadlines(userId, 2025, 6)
-
-            assertEquals(1, response.monthlyScrapDeadline.size)
-            val group = response.monthlyScrapDeadline.first()
-            assertEquals("2025-06-30", group.deadline)
-            assertEquals(1, group.scraps.size)
-            assertEquals(scrapId, group.scraps.first().scrapId)
-            assertEquals("테스트 공고", group.scraps.first().title)
-            assertEquals("#4AA9F2", group.scraps.first().color)
-        }
-
-        @Test
-        @DisplayName("스크랩 ID가 null이면 예외가 발생한다")
-        fun throwsExceptionWhenScrapIdIsNull() {
-            val deadline = LocalDate.of(2025, 6, 30)
-
-            val title = mockk<InternshipTitle>()
-            every { title.value } returns "테스트 공고"
-
-            val announcementDeadline =
-                mockk<InternshipAnnouncementDeadline>()
-            every { announcementDeadline.value } returns deadline
-
-            val internshipAnnouncement = mockk<InternshipAnnouncement>()
-            every { internshipAnnouncement.title } returns title
-            every { internshipAnnouncement.internshipAnnouncementDeadline } returns announcementDeadline
-
-            val scrap = mockk<Scrap>()
-            every { scrap.id } returns null
-            every { scrap.internshipAnnouncement } returns internshipAnnouncement
-
-            every {
-                scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(any(), any(), any())
-            } returns listOf(scrap)
-
-            val exception =
-                assertThrows(ScrapException::class.java) {
-                    scrapService.monthlyScrapDeadlines(userId, 2025, 6)
-                }
-
-            assertEquals(ScrapErrorCode.SCRAP_ID_NULL, exception.errorCode)
-        }
+    private fun givenScrapExists() {
+        every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns true
     }
 
-    @Nested
-    @DisplayName("상세 월간 스크랩 조회")
-    inner class DetailedMonthlyScrapTest {
-        @Test
-        @DisplayName("마감일 기준으로 상세 스크랩 정보를 반환한다")
-        fun returnsDetailedScrapsByDeadline() {
-            val deadline = LocalDate.now().plusDays(3)
-            val workingPeriod = 6
+    private fun givenScrapDoesNotExist() {
+        every { scrapRepository.existsByUserIdAndInternshipAnnouncementId(userId, announcementId) } returns false
+    }
 
-            val announcement = mockk<InternshipAnnouncement>()
-            every { announcement.id } returns 1L
-            every { announcement.company.logoUrl.value } returns "http://image.url/logo.png"
-            every { announcement.title.value } returns "상세 공고"
-            every { announcement.workingPeriod.toString() } returns "${workingPeriod}개월"
-            every { announcement.internshipAnnouncementDeadline.value } returns deadline
-            every { announcement.startDate.year.value } returns 2025
-            every { announcement.startDate.month.value } returns 6
+    private fun givenAnnouncementExists(announcement: InternshipAnnouncement) {
+        every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(announcement)
+    }
 
-            val scrap = mockk<Scrap>()
-            every { scrap.internshipAnnouncement } returns announcement
-            every { scrap.hexColor() } returns "#123456"
-
-            every {
-                scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(any(), any(), any())
-            } returns listOf(scrap)
-
-            val response = scrapService.detailedMonthlyScraps(userId, 2025, 6)
-
-            val group = response.dailyGroups.first()
-            val detailedScrap = group.scraps.first()
-
-            assertEquals("1", detailedScrap.announcementId.toString())
-            assertEquals("상세 공고", detailedScrap.title)
-            assertEquals("#123456", detailedScrap.hexColor)
-            assertEquals("${workingPeriod}개월", detailedScrap.workingPeriod)
-            assertEquals(true, detailedScrap.isScrapped)
-            assertEquals(deadline, detailedScrap.deadline)
-            assertEquals("2025년 6월", detailedScrap.startYearMonth)
-        }
-
-        @Test
-        @DisplayName("공고 ID가 null이면 예외가 발생한다")
-        fun throwsExceptionWhenAnnouncementIdIsNull() {
-            val deadline = LocalDate.now().plusDays(3)
-
-            val announcement = mockk<InternshipAnnouncement>()
-            every { announcement.id } returns null
-            every { announcement.company.logoUrl.value } returns "http://image.url/logo.png"
-            every { announcement.title.value } returns "상세 공고"
-            every { announcement.workingPeriod.toString() } returns "6개월"
-            every { announcement.internshipAnnouncementDeadline.value } returns deadline
-            every { announcement.startDate.year.value } returns 2025
-            every { announcement.startDate.month.value } returns 6
-
-            val scrap = mockk<Scrap>()
-            every { scrap.internshipAnnouncement } returns announcement
-
-            every {
-                scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(any(), any(), any())
-            } returns listOf(scrap)
-
-            val exception =
-                assertThrows(ScrapException::class.java) {
-                    scrapService.detailedMonthlyScraps(userId, 2025, 6)
-                }
-
-            assertEquals(ScrapErrorCode.SCRAP_ID_NULL, exception.errorCode)
-        }
+    private fun givenUserAndAnnouncementExist(user: User, announcement: InternshipAnnouncement) {
+        givenAnnouncementExists(announcement)
+        every { userRepository.findById(userId) } returns Optional.of(user)
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/scrap/ScrapServiceTest.kt
@@ -197,7 +197,10 @@ class ScrapServiceTest {
         every { internshipAnnouncementRepository.findById(announcementId) } returns Optional.of(announcement)
     }
 
-    private fun givenUserAndAnnouncementExist(user: User, announcement: InternshipAnnouncement) {
+    private fun givenUserAndAnnouncementExist(
+        user: User,
+        announcement: InternshipAnnouncement,
+    ) {
         givenAnnouncementExists(announcement)
         every { userRepository.findById(userId) } returns Optional.of(user)
     }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/filter/FilterControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/filter/FilterControllerTest.kt
@@ -1,0 +1,61 @@
+package com.terning.server.kotlin.ui.api.filter
+
+import com.ninjasquad.springmockk.MockkBean
+import com.terning.server.kotlin.application.filter.FilterResponse
+import com.terning.server.kotlin.application.filter.FilterService
+import com.terning.server.kotlin.ui.api.FilterController
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@WebMvcTest(FilterController::class)
+@ActiveProfiles("test")
+class FilterControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var filterService: FilterService
+
+    private lateinit var filterResponse: FilterResponse
+
+    @BeforeEach
+    fun setUp() {
+        filterResponse =
+            FilterResponse(
+                jobType = "it",
+                grade = "senior",
+                workingPeriod = "short",
+                startYear = 2024,
+                startMonth = 12,
+            )
+    }
+
+    @Test
+    @DisplayName("필터링 정보를 가져온다")
+    fun getFilter() {
+        // given
+        val userId = 1L
+        every { filterService.getUserFilter(userId = userId) } returns filterResponse
+
+        // when
+        mockMvc.get("/api/v1/filters") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            // then
+            status { isOk() }
+            jsonPath("$.result.jobType") { value("it") }
+            jsonPath("$.result.grade") { value("senior") }
+            jsonPath("$.result.workingPeriod") { value("short") }
+            jsonPath("$.result.startYear") { value(2024) }
+            jsonPath("$.result.startMonth") { value(12) }
+        }
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/filter/FilterControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/filter/FilterControllerTest.kt
@@ -33,8 +33,8 @@ class FilterControllerTest {
                 jobType = "it",
                 grade = "senior",
                 workingPeriod = "short",
-                startYear = 2024,
-                startMonth = 12,
+                startYear = 2025,
+                startMonth = 6,
             )
     }
 
@@ -54,8 +54,8 @@ class FilterControllerTest {
             jsonPath("$.result.jobType") { value("it") }
             jsonPath("$.result.grade") { value("senior") }
             jsonPath("$.result.workingPeriod") { value("short") }
-            jsonPath("$.result.startYear") { value(2024) }
-            jsonPath("$.result.startMonth") { value(12) }
+            jsonPath("$.result.startYear") { value(2025) }
+            jsonPath("$.result.startMonth") { value(6) }
         }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
@@ -64,29 +64,28 @@ class ScrapControllerTest {
                 ZoneId.systemDefault(),
             )
 
+        val detailedScrap = DetailedScrap.from(
+            announcementId = 1L,
+            companyImageUrl = "https://test.image/logo.png",
+            title = "백엔드 인턴 모집",
+            workingPeriod = "3개월",
+            isScrapped = true,
+            hexColor = "#123456",
+            deadline = LocalDate.of(2025, 6, 30),
+            startYear = 2025,
+            startMonth = 7,
+            clock = clock,
+        )
+
         val detailedResponse =
             DetailedMonthlyScrapResponse(
                 dailyGroups =
-                    listOf(
-                        DetailedScrapGroup(
-                            deadline = "2025-06-30",
-                            scraps =
-                                listOf(
-                                    DetailedScrap.from(
-                                        announcementId = 1L,
-                                        companyImageUrl = "https://test.image/logo.png",
-                                        title = "백엔드 인턴 모집",
-                                        workingPeriod = "3개월",
-                                        isScrapped = true,
-                                        hexColor = "#123456",
-                                        deadline = LocalDate.of(2025, 6, 30),
-                                        startYear = 2025,
-                                        startMonth = 7,
-                                        clock = clock,
-                                    ),
-                                ),
-                        ),
+                listOf(
+                    DetailedScrapGroup(
+                        deadline = "2025-06-30",
+                        scraps = listOf(detailedScrap),
                     ),
+                ),
             )
 
         every { scrapService.detailedMonthlyScraps(userId, year, month) } returns detailedResponse
@@ -99,13 +98,15 @@ class ScrapControllerTest {
             status { isOk() }
             jsonPath("$.status") { value(200) }
             jsonPath("$.result.dailyGroups[0].deadline") { value("2025-06-30") }
-            jsonPath("$.result.dailyGroups[0].scraps[0].announcementId") { value(1) }
-            jsonPath("$.result.dailyGroups[0].scraps[0].companyImageUrl") { value("https://test.image/logo.png") }
+            jsonPath("$.result.dailyGroups[0].scraps[0].internshipAnnouncementId") { value(1) }
+            jsonPath("$.result.dailyGroups[0].scraps[0].companyImage") { value("https://test.image/logo.png") }
             jsonPath("$.result.dailyGroups[0].scraps[0].title") { value("백엔드 인턴 모집") }
             jsonPath("$.result.dailyGroups[0].scraps[0].workingPeriod") { value("3개월") }
-            jsonPath("$.result.dailyGroups[0].scraps[0].deadlineText") { value("2025년 6월 30일") }
+            jsonPath("$.result.dailyGroups[0].scraps[0].isScrapped") { value(true) }
+            jsonPath("$.result.dailyGroups[0].scraps[0].color") { value("#123456") }
+            jsonPath("$.result.dailyGroups[0].scraps[0].deadline") { value("2025년 6월 30일") }
             jsonPath("$.result.dailyGroups[0].scraps[0].startYearMonth") { value("2025년 7월") }
-            jsonPath("$.result.dailyGroups[0].scraps[0].formattedDeadline") { value("D-5") }
+            jsonPath("$.result.dailyGroups[0].scraps[0].dday") { value("D-5") }
         }
     }
 

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/scrap/ScrapControllerTest.kt
@@ -64,28 +64,29 @@ class ScrapControllerTest {
                 ZoneId.systemDefault(),
             )
 
-        val detailedScrap = DetailedScrap.from(
-            announcementId = 1L,
-            companyImageUrl = "https://test.image/logo.png",
-            title = "백엔드 인턴 모집",
-            workingPeriod = "3개월",
-            isScrapped = true,
-            hexColor = "#123456",
-            deadline = LocalDate.of(2025, 6, 30),
-            startYear = 2025,
-            startMonth = 7,
-            clock = clock,
-        )
+        val detailedScrap =
+            DetailedScrap.from(
+                announcementId = 1L,
+                companyImageUrl = "https://test.image/logo.png",
+                title = "백엔드 인턴 모집",
+                workingPeriod = "3개월",
+                isScrapped = true,
+                hexColor = "#123456",
+                deadline = LocalDate.of(2025, 6, 30),
+                startYear = 2025,
+                startMonth = 7,
+                clock = clock,
+            )
 
         val detailedResponse =
             DetailedMonthlyScrapResponse(
                 dailyGroups =
-                listOf(
-                    DetailedScrapGroup(
-                        deadline = "2025-06-30",
-                        scraps = listOf(detailedScrap),
+                    listOf(
+                        DetailedScrapGroup(
+                            deadline = "2025-06-30",
+                            scraps = listOf(detailedScrap),
+                        ),
                     ),
-                ),
             )
 
         every { scrapService.detailedMonthlyScraps(userId, year, month) } returns detailedResponse


### PR DESCRIPTION
# 📄 Work Description  
- 월간 캘린더(리스트형) 상세 조회 API (`/api/v1/calendar/monthly-list`)를 구현했습니다.
- 응답값은 마감일 기준으로 그룹화된 스크랩 목록입니다.
- `D-DAY`, `지원마감`, `D-N` 등 마감일 포맷을 위해 날짜 비교 로직을 적용했습니다.
- 테스트 시 `LocalDate.now()`로 인해 값이 달라지는 문제를 방지하기 위해 `Clock`을 도입하고, `ClockConfig`를 통해 Clock을 Bean으로 주입받도록 설정했습니다.
- `DetailedScrap.from(...)` 정적 팩토리 메서드에 Clock을 전달받도록 변경하여 테스트 가능성을 확보했습니다.

# 💭 Thoughts 
- 기존에는 `LocalDate.now()`를 직접 호출하고 있었기 때문에 테스트에서 날짜 포맷(`D-5`, `지원마감`) 검증이 어려웠습니다.
- 이를 해결하기 위해 `Clock`을 주입받는 방식으로 구조를 개선했고, 테스트에서는 `Clock.fixed(...)`를 통해 오늘 날짜를 고정하여 테스트할 수 있도록 했습니다.
- 객체 생성 시 필요한 값을 줄이기 위해 `DetailedScrap` 내부에서 파생되는 필드(`deadlineText`, `startYearMonth`)는 프로퍼티에서 계산되도록 처리했습니다.

# ✅ Testing Result  
<img width="368" alt="스크린샷 2025-06-08 오후 5 04 24" src="https://github.com/user-attachments/assets/2d2dd7f6-a150-4c07-901b-d94501bb727d" />
<img width="418" alt="스크린샷 2025-06-08 오후 5 04 49" src="https://github.com/user-attachments/assets/ee58437c-5110-4066-9333-c04422ea2af0" />



# 🗂 Related Issue  
- closed #95 
