### PR TITLE
[✨feat] 필터링 재설정 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
@@ -34,4 +34,18 @@ class FilterService(
             startMonth = startDate.filterMonth.value,
         )
     }
+
+    @Transactional
+    fun postUserFilter(userId: Long)
+  //  : FilterResponse
+    {
+        val user =
+            userRepository.findById(userId).orElseThrow {
+                FilterException(FilterErrorCode.NOT_FOUND_USER_EXCEPTION)
+            }
+
+//        val filter =
+//
+//        return
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
@@ -1,8 +1,11 @@
 package com.terning.server.kotlin.application.filter
 
+import com.terning.server.kotlin.application.filter.dto.FilterRequest
+import com.terning.server.kotlin.application.filter.dto.FilterResponse
 import com.terning.server.kotlin.domain.filter.FilterRepository
 import com.terning.server.kotlin.domain.filter.exception.FilterErrorCode
 import com.terning.server.kotlin.domain.filter.exception.FilterException
+import com.terning.server.kotlin.domain.filter.vo.*
 import com.terning.server.kotlin.domain.user.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -36,16 +39,28 @@ class FilterService(
     }
 
     @Transactional
-    fun postUserFilter(userId: Long)
-  //  : FilterResponse
-    {
+    fun updateUserFilter(
+        userId: Long,
+        filterRequest: FilterRequest,
+    ) {
         val user =
             userRepository.findById(userId).orElseThrow {
                 FilterException(FilterErrorCode.NOT_FOUND_USER_EXCEPTION)
             }
 
-//        val filter =
-//
-//        return
+        val filter =
+            filterRepository.findLatestByUser(user)
+                ?: throw FilterException(FilterErrorCode.NOT_FOUND_FILTER_EXCEPTION)
+
+        filter.updateFilter(
+            newFilterJobType = FilterJobType.from(filterRequest.jobType),
+            newFilterGrade = FilterGrade.from(filterRequest.grade),
+            newFilterWorkingPeriod = FilterWorkingPeriod.from(filterRequest.workingPeriod),
+            newFilterStartDate =
+                FilterStartDate.of(
+                    filterMonth = FilterMonth.from(filterRequest.startMonth),
+                    filterYear = FilterYear.from(filterRequest.startYear),
+                ),
+        )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/FilterService.kt
@@ -5,7 +5,12 @@ import com.terning.server.kotlin.application.filter.dto.FilterResponse
 import com.terning.server.kotlin.domain.filter.FilterRepository
 import com.terning.server.kotlin.domain.filter.exception.FilterErrorCode
 import com.terning.server.kotlin.domain.filter.exception.FilterException
-import com.terning.server.kotlin.domain.filter.vo.*
+import com.terning.server.kotlin.domain.filter.vo.FilterGrade
+import com.terning.server.kotlin.domain.filter.vo.FilterJobType
+import com.terning.server.kotlin.domain.filter.vo.FilterMonth
+import com.terning.server.kotlin.domain.filter.vo.FilterStartDate
+import com.terning.server.kotlin.domain.filter.vo.FilterWorkingPeriod
+import com.terning.server.kotlin.domain.filter.vo.FilterYear
 import com.terning.server.kotlin.domain.user.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/dto/FilterRequest.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/dto/FilterRequest.kt
@@ -1,0 +1,9 @@
+package com.terning.server.kotlin.application.filter.dto
+
+data class FilterRequest(
+    val jobType: String,
+    val grade: String,
+    val workingPeriod: String,
+    val startYear: Int,
+    val startMonth: Int,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/application/filter/dto/FilterResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/filter/dto/FilterResponse.kt
@@ -1,4 +1,4 @@
-package com.terning.server.kotlin.application.filter
+package com.terning.server.kotlin.application.filter.dto
 
 data class FilterResponse(
     val jobType: String,

--- a/src/main/kotlin/com/terning/server/kotlin/domain/filter/Filter.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/filter/Filter.kt
@@ -50,7 +50,7 @@ class Filter private constructor(
     )
     private var filterStartDate: FilterStartDate,
 ) : BaseRootEntity() {
-    fun update(
+    fun updateFilter(
         newFilterJobType: FilterJobType,
         newFilterGrade: FilterGrade,
         newFilterWorkingPeriod: FilterWorkingPeriod,

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
@@ -37,12 +37,20 @@ class FilterController(
     fun updateUserFilter(
         // TODO: @AuthenticationPrincipal userId: Long,
         @RequestBody filterRequest: FilterRequest,
-    ) {
+    ): ResponseEntity<ApiResponse<Unit>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
         filterService.updateUserFilter(
             userId = userId,
             filterRequest = filterRequest,
+        )
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "필터링 재설정에 성공했습니다",
+                result = Unit,
+            ),
         )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
@@ -5,6 +5,7 @@ import com.terning.server.kotlin.application.filter.FilterService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -25,6 +26,23 @@ class FilterController(
             ApiResponse.success(
                 status = HttpStatus.OK,
                 message = "사용자의 필터링 정보를 불러오는데 성공했습니다",
+                result = response,
+            ),
+        )
+    }
+
+    @PutMapping("filters")
+    fun putUserFilter(
+        // TODO: @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<FilterResponse>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        val response = filterService.postUserFilter(userId)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "필터링 재설정에 성공했습니다",
                 result = response,
             ),
         )

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
@@ -1,11 +1,13 @@
 package com.terning.server.kotlin.ui.api
 
-import com.terning.server.kotlin.application.filter.FilterResponse
 import com.terning.server.kotlin.application.filter.FilterService
+import com.terning.server.kotlin.application.filter.dto.FilterRequest
+import com.terning.server.kotlin.application.filter.dto.FilterResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -32,19 +34,15 @@ class FilterController(
     }
 
     @PutMapping("filters")
-    fun putUserFilter(
+    fun updateUserFilter(
         // TODO: @AuthenticationPrincipal userId: Long,
-    ): ResponseEntity<ApiResponse<FilterResponse>> {
+        @RequestBody filterRequest: FilterRequest,
+    ) {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
-        val response = filterService.postUserFilter(userId)
-
-        return ResponseEntity.ok(
-            ApiResponse.success(
-                status = HttpStatus.OK,
-                message = "필터링 재설정에 성공했습니다",
-                result = response,
-            ),
+        filterService.updateUserFilter(
+            userId = userId,
+            filterRequest = filterRequest,
         )
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/filter/FilterServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/filter/FilterServiceTest.kt
@@ -13,7 +13,9 @@ import com.terning.server.kotlin.domain.filter.vo.FilterWorkingPeriod
 import com.terning.server.kotlin.domain.filter.vo.FilterYear
 import com.terning.server.kotlin.domain.user.User
 import com.terning.server.kotlin.domain.user.UserRepository
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/com/terning/server/kotlin/domain/filter/FilterTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/domain/filter/FilterTest.kt
@@ -41,7 +41,7 @@ class FilterTest {
     fun updateFilter() {
         val filter = Filter.of(user, filterJobType, filterGrade, filterWorkingPeriod, filterStartDate)
 
-        filter.update(newFilterJobType, newFilterGrade, newFilterWorkingPeriod, newFilterStartDate)
+        filter.updateFilter(newFilterJobType, newFilterGrade, newFilterWorkingPeriod, newFilterStartDate)
 
         assertThat(filter.jobType()).isEqualTo(newFilterJobType)
         assertThat(filter.grade()).isEqualTo(newFilterGrade)

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/filter/FilterControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/filter/FilterControllerTest.kt
@@ -1,8 +1,8 @@
 package com.terning.server.kotlin.ui.api.filter
 
 import com.ninjasquad.springmockk.MockkBean
-import com.terning.server.kotlin.application.filter.dto.FilterResponse
 import com.terning.server.kotlin.application.filter.FilterService
+import com.terning.server.kotlin.application.filter.dto.FilterResponse
 import com.terning.server.kotlin.ui.api.FilterController
 import io.mockk.every
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/filter/FilterControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/filter/FilterControllerTest.kt
@@ -1,7 +1,7 @@
 package com.terning.server.kotlin.ui.api.filter
 
 import com.ninjasquad.springmockk.MockkBean
-import com.terning.server.kotlin.application.filter.FilterResponse
+import com.terning.server.kotlin.application.filter.dto.FilterResponse
 import com.terning.server.kotlin.application.filter.FilterService
 import com.terning.server.kotlin.ui.api.FilterController
 import io.mockk.every


### PR DESCRIPTION
# 📄 Work Description  
-  필터링 재설정 API 구현했습니다.
- 사용자가 요청한 정보가 정상적으로 업데이트 되는지 controller, service 코드를 작성했습니다.

# 💭 Thoughts 
- 한 가지 고민되었던 부분은 현재 `FilterRequest`와 `FilterResponse`가 완전히 똑같은 형태인데 이를 하나로 만들어 재사용할지, 그래도 따로 나눠서 사용할지였어요! 일단 제가 내린 결론은.. 그래도 요청하는 값과 응답 값을 분리하는 게 좋을 것 같아서 별도로 작성해주었습니다. 어떻게 생각하시나요?
- 그리고 저도 QueryDSL을 사용해볼까 하다가 현재 PR에서는 사용하지 않았습니다!

# ✅ Testing Result  
<img width="390" alt="image" src="https://github.com/user-attachments/assets/fd00ed7a-c3eb-42a5-8c2c-01116b9af4da" />
<img width="391" alt="image" src="https://github.com/user-attachments/assets/5034d221-0af5-4f08-9b5c-f095a483348e" />


# 🗂 Related Issue  
- closed #93
