### PR TITLE
[✨feat] 곧 마감되는 관심 공고 

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/ScrapService.kt
@@ -8,6 +8,8 @@ import com.terning.server.kotlin.application.scrap.dto.MonthlyScrapDeadlineRespo
 import com.terning.server.kotlin.application.scrap.dto.MonthlyScrapDeadlineSummary
 import com.terning.server.kotlin.application.scrap.dto.ScrapRequest
 import com.terning.server.kotlin.application.scrap.dto.ScrapUpdateRequest
+import com.terning.server.kotlin.application.scrap.dto.UpcomingDeadlineScrapDetail
+import com.terning.server.kotlin.application.scrap.dto.UpcomingDeadlineScrapResponse
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
 import com.terning.server.kotlin.domain.scrap.Scrap
 import com.terning.server.kotlin.domain.scrap.ScrapRepository
@@ -15,6 +17,8 @@ import com.terning.server.kotlin.domain.scrap.exception.ScrapErrorCode
 import com.terning.server.kotlin.domain.scrap.exception.ScrapException
 import com.terning.server.kotlin.domain.scrap.vo.Color
 import com.terning.server.kotlin.domain.user.UserRepository
+import com.terning.server.kotlin.domain.user.exception.UserErrorCode
+import com.terning.server.kotlin.domain.user.exception.UserException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -195,5 +199,48 @@ class ScrapService(
                 clock = clock,
             )
         }
+    }
+
+    fun findUpcomingDeadlineScraps(userId: Long): UpcomingDeadlineScrapResponse {
+        if (!userRepository.existsById(userId)) {
+            throw UserException(UserErrorCode.USER_NOT_FOUND)
+        }
+
+        if (!scrapRepository.existsByUserId(userId)) {
+            return UpcomingDeadlineScrapResponse(
+                hasScrapped = false,
+                message = "아직 스크랩된 인턴 공고가 없어요!",
+                scraps = emptyList(),
+            )
+        }
+
+        val today = LocalDate.now(clock)
+        val sevenDaysLater = today.plusDays(7)
+
+        val upcomingScraps =
+            scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(
+                userId = userId,
+                start = today,
+                end = sevenDaysLater,
+            )
+
+        if (upcomingScraps.isEmpty()) {
+            return UpcomingDeadlineScrapResponse(
+                hasScrapped = true,
+                message = "일주일 내에 마감인 공고가 없어요\n캘린더에서 스크랩한 공고 일정을 확인해 보세요",
+                scraps = emptyList(),
+            )
+        }
+
+        val scrapDetails =
+            upcomingScraps.map { scrap ->
+                UpcomingDeadlineScrapDetail.of(scrap, clock)
+            }
+
+        return UpcomingDeadlineScrapResponse(
+            hasScrapped = true,
+            message = "곧 마감되는 스크랩 공고를 성공적으로 조회했습니다.",
+            scraps = scrapDetails,
+        )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/scrap/dto/UpcomingDeadlineScrapResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/scrap/dto/UpcomingDeadlineScrapResponse.kt
@@ -1,0 +1,57 @@
+package com.terning.server.kotlin.application.scrap.dto
+
+import com.terning.server.kotlin.domain.scrap.Scrap
+import java.time.Clock
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+data class UpcomingDeadlineScrapResponse(
+    val hasScrapped: Boolean,
+    val message: String,
+    val scraps: List<UpcomingDeadlineScrapDetail>,
+)
+
+data class UpcomingDeadlineScrapDetail(
+    val internshipAnnouncementId: Long,
+    val companyImage: String,
+    val companyInfo: String,
+    val title: String,
+    val dDay: String,
+    val workingPeriod: String,
+    val isScrapped: Boolean,
+    val color: String,
+    val deadline: String,
+    val startYearMonth: String,
+) {
+    companion object {
+        fun of(
+            scrap: Scrap,
+            clock: Clock,
+        ): UpcomingDeadlineScrapDetail {
+            val announcement = scrap.internshipAnnouncement
+            val today = LocalDate.now(clock)
+
+            val deadlineDate = announcement.internshipAnnouncementDeadline.value
+            val daysUntilDeadline = ChronoUnit.DAYS.between(today, deadlineDate)
+
+            val dDayString =
+                when {
+                    daysUntilDeadline == 0L -> "D-DAY"
+                    else -> "D-$daysUntilDeadline"
+                }
+
+            return UpcomingDeadlineScrapDetail(
+                internshipAnnouncementId = announcement.id!!,
+                companyImage = announcement.company.logoUrl.value,
+                companyInfo = announcement.company.name.value,
+                title = announcement.title.value,
+                dDay = dDayString,
+                workingPeriod = announcement.workingPeriod.toString(),
+                isScrapped = true,
+                color = scrap.hexColor(),
+                deadline = deadlineDate.toString(),
+                startYearMonth = "${announcement.startDate.year.value}년 ${announcement.startDate.month.value}월",
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepositoryCustom.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepositoryCustom.kt
@@ -3,6 +3,8 @@ package com.terning.server.kotlin.domain.scrap
 import java.time.LocalDate
 
 interface ScrapRepositoryCustom {
+    fun existsByUserId(userId: Long): Boolean
+
     fun findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(
         userId: Long,
         start: LocalDate,

--- a/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepositoryImpl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/scrap/ScrapRepositoryImpl.kt
@@ -8,6 +8,17 @@ import java.time.LocalDate
 class ScrapRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : ScrapRepositoryCustom {
+    override fun existsByUserId(userId: Long): Boolean {
+        val scrap = QScrap.scrap
+        val fetchFirst =
+            queryFactory
+                .selectOne()
+                .from(scrap)
+                .where(scrap.user.id.eq(userId))
+                .fetchFirst()
+        return fetchFirst != null
+    }
+
     override fun findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(
         userId: Long,
         start: LocalDate,

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/exception/UserErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/exception/UserErrorCode.kt
@@ -9,4 +9,5 @@ enum class UserErrorCode(
 ) : BaseErrorCode {
     NOT_FOUND_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 유저가 존재하지 않습니다"),
     INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 프로필 이미지 입니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 유저를 찾을 수 없습니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -6,6 +6,7 @@ import com.terning.server.kotlin.application.scrap.dto.DetailedScrap
 import com.terning.server.kotlin.application.scrap.dto.MonthlyScrapDeadlineResponse
 import com.terning.server.kotlin.application.scrap.dto.ScrapRequest
 import com.terning.server.kotlin.application.scrap.dto.ScrapUpdateRequest
+import com.terning.server.kotlin.application.scrap.dto.UpcomingDeadlineScrapResponse
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -25,6 +26,22 @@ import java.time.LocalDate
 class ScrapController(
     private val scrapService: ScrapService,
 ) {
+    @GetMapping("/home/upcoming")
+    fun getUpcomingDeadlineScraps(
+        // TODO: @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<UpcomingDeadlineScrapResponse>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 교체
+        val response = scrapService.findUpcomingDeadlineScraps(userId)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = response.message,
+                result = response,
+            ),
+        )
+    }
+
     @GetMapping("/calendar/daily")
     fun dailyScraps(
         // TODO: @AuthenticationPrincipal userId: Long,


### PR DESCRIPTION
# 📄 Work Description

  - 홈 화면 - `곧 마감되는 스크랩 공고 조회` API (`GET /api/v1/home/upcoming`)를 구현했습니다.
  - API 명세에 따라 아래 3가지 시나리오에 맞춰 응답을 분기 처리했습니다.
    1.  스크랩한 공고가 없는 경우
    2.  스크랩은 했지만, 7일 내 마감되는 공고가 없는 경우
    3.  7일 내 마감되는 공고가 존재하는 경우
  - `ScrapRepository`에 유저의 스크랩 존재 여부(`existsByUserId`)와 특정 기간 내 마감 공고를 조회하는(`find...BetweenOrderByDeadline`) 쿼리를 추가했습니다.

# 💭 Thoughts

  - 응답 메시지, Controller와 Service 중 어디서 생성해야 할까? 고민이 있었습니다.
  - 이번 API는 단순한 성공/실패가 아닌, 데이터의 상태에 따라 사용자에게 전달해야 할 메시지가 3가지로 나뉘는 복잡한 케이스였습니다.
  - 만약 다른 API처럼 Controller에서 메시지를 생성한다면, Service가 반환한 데이터의 내용을 Controller가 `if-else`로 확인하며 어떤 메시지를 보낼지 결정해야 합니다. 이는 Controller가 비즈니스 로직의 일부를 책임지게 만들어 계층 간의 역할과 책임 원칙을 해친다고 판단했습니다.
  - 따라서 데이터의 상태를 가장 잘 알고 있는 `Service`가 그 상태에 맞는 메시지까지 온전히 결정하여 반환하는 것이 최선이라고 결론 내렸습니다. 이로써 Controller는 Service의 판단을 그대로 신뢰하고 전달하는 역할에만 집중할 수 있어, 더 깔끔하고 유지보수하기 좋은 구조가 된 것 같은데 어떻게 생각하시나요!

# ✅ Testing Result
<img width="692" alt="스크린샷 2025-06-13 오전 8 08 21" src="https://github.com/user-attachments/assets/dd512449-facb-4919-bb08-ad89e39d4643" />

<img width="687" alt="스크린샷 2025-06-13 오전 8 08 35" src="https://github.com/user-attachments/assets/3c51affa-5d64-46c7-8531-93d3d4c21d32" />


# 🗂 Related Issue

  - closed \#105