### PR TITLE
[✨feat] 검색 결과 화면 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/home/HomeService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/home/HomeService.kt
@@ -105,9 +105,11 @@ class HomeService(
         sortBy: String,
         pageable: Pageable,
     ): Page<Tuple> {
+        val now = LocalDate.now(clock)
+
         if (filter == null || filter.isDefault()) {
-            return internshipRepository.findAllInternshipsWithScrapInfo(user, sortBy, pageable)
+            return internshipRepository.findAllInternshipsWithScrapInfo(user, sortBy, pageable, now)
         }
-        return internshipRepository.findFilteredInternshipsWithScrapInfo(user, filter, sortBy, pageable)
+        return internshipRepository.findFilteredInternshipsWithScrapInfo(user, filter, sortBy, pageable, now)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
@@ -29,13 +29,15 @@ class SearchService(
             userRepository.findById(userId)
                 .orElseThrow { UserException(UserErrorCode.USER_NOT_FOUND) }
 
+        val currentDate = LocalDate.now(clock)
+
         val announcementTuples =
             internshipAnnouncementRepository.findByKeywordWithScrapInfo(
                 user = user,
                 keyword = keyword,
                 sortBy = sortBy,
                 pageable = pageable,
-                now = LocalDate.now(clock),
+                now = currentDate,
             )
 
         val announcementResponse = announcementTuples.map { tuple -> SearchAnnouncementResponse.of(tuple, clock) }

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
@@ -1,0 +1,45 @@
+package com.terning.server.kotlin.application.search
+
+import com.terning.server.kotlin.application.search.dto.SearchAnnouncementResponse
+import com.terning.server.kotlin.application.search.dto.SearchPageResponse
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
+import com.terning.server.kotlin.domain.user.UserRepository
+import com.terning.server.kotlin.domain.user.exception.UserErrorCode
+import com.terning.server.kotlin.domain.user.exception.UserException
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDate
+
+@Service
+@Transactional(readOnly = true)
+class SearchService(
+    private val internshipAnnouncementRepository: InternshipAnnouncementRepository,
+    private val userRepository: UserRepository,
+    private val clock: Clock,
+) {
+    fun search(
+        userId: Long,
+        keyword: String?,
+        sortBy: String,
+        pageable: Pageable,
+    ): SearchPageResponse {
+        val user =
+            userRepository.findById(userId)
+                .orElseThrow { UserException(UserErrorCode.USER_NOT_FOUND) }
+
+        val announcementTuples =
+            internshipAnnouncementRepository.findByKeywordWithScrapInfo(
+                user = user,
+                keyword = keyword,
+                sortBy = sortBy,
+                pageable = pageable,
+                now = LocalDate.now(clock),
+            )
+
+        val announcementResponse = announcementTuples.map { tuple -> SearchAnnouncementResponse.of(tuple, clock) }
+
+        return SearchPageResponse.from(announcementResponse)
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/dto/SearchPageResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/dto/SearchPageResponse.kt
@@ -1,0 +1,80 @@
+package com.terning.server.kotlin.application.search.dto
+
+import com.querydsl.core.Tuple
+import com.terning.server.kotlin.domain.internshipAnnouncement.QInternshipAnnouncement.internshipAnnouncement
+import com.terning.server.kotlin.domain.scrap.QScrap.scrap
+import org.springframework.data.domain.Page
+import java.time.Clock
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+data class SearchPageResponse(
+    val totalPages: Int,
+    val totalCount: Long,
+    val hasNext: Boolean,
+    val announcements: List<SearchAnnouncementResponse>,
+) {
+    companion object {
+        fun from(page: Page<SearchAnnouncementResponse>): SearchPageResponse {
+            return SearchPageResponse(
+                totalPages = page.totalPages,
+                totalCount = page.totalElements,
+                hasNext = page.hasNext(),
+                announcements = page.content,
+            )
+        }
+    }
+}
+
+data class SearchAnnouncementResponse(
+    val internshipAnnouncementId: Long,
+    val companyImage: String,
+    val dDay: String,
+    val title: String,
+    val workingPeriod: String,
+    val isScrapped: Boolean,
+    val color: String?,
+    val deadline: String,
+    val startYearMonth: String,
+) {
+    companion object {
+        fun of(
+            tuple: Tuple,
+            clock: Clock,
+        ): SearchAnnouncementResponse {
+            val announcement = tuple.get(internshipAnnouncement)!!
+            val scrapColor = tuple.get(scrap.color)
+
+            return SearchAnnouncementResponse(
+                internshipAnnouncementId = announcement.id!!,
+                companyImage = announcement.company.logoUrl.value,
+                dDay = calculateDday(announcement.internshipAnnouncementDeadline.value, clock),
+                title = announcement.title.value,
+                workingPeriod = announcement.workingPeriod.toString(),
+                isScrapped = scrapColor != null,
+                color = scrapColor?.toHexString(),
+                deadline = formatDate(announcement.internshipAnnouncementDeadline.value),
+                startYearMonth = "${announcement.startDate.year.value}년 ${announcement.startDate.month.value}월",
+            )
+        }
+
+        private fun calculateDday(
+            deadline: LocalDate?,
+            clock: Clock,
+        ): String {
+            if (deadline == null) return "채용 시 마감"
+
+            val daysLeft = ChronoUnit.DAYS.between(LocalDate.now(clock), deadline)
+            return when {
+                daysLeft < 0 -> "지원마감"
+                daysLeft == 0L -> "D-day"
+                else -> "D-$daysLeft"
+            }
+        }
+
+        private fun formatDate(date: LocalDate?): String {
+            return date?.format(DateTimeFormatter.ofPattern("yyyy년 M월 d일")) ?: "채용 시 마감"
+        }
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryCustom.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryCustom.kt
@@ -5,12 +5,14 @@ import com.terning.server.kotlin.domain.filter.Filter
 import com.terning.server.kotlin.domain.user.User
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import java.time.LocalDate
 
 interface InternshipAnnouncementRepositoryCustom {
     fun findAllInternshipsWithScrapInfo(
         user: User,
         sortBy: String,
         pageable: Pageable,
+        now: LocalDate,
     ): Page<Tuple>
 
     fun findFilteredInternshipsWithScrapInfo(
@@ -18,5 +20,14 @@ interface InternshipAnnouncementRepositoryCustom {
         filter: Filter,
         sortBy: String,
         pageable: Pageable,
+        now: LocalDate,
+    ): Page<Tuple>
+
+    fun findByKeywordWithScrapInfo(
+        user: User,
+        keyword: String?,
+        sortBy: String,
+        pageable: Pageable,
+        now: LocalDate,
     ): Page<Tuple>
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryImpl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryImpl.kt
@@ -1,6 +1,9 @@
 package com.terning.server.kotlin.domain.internshipAnnouncement
 
 import com.querydsl.core.Tuple
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.CaseBuilder
 import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.terning.server.kotlin.domain.filter.Filter
@@ -13,6 +16,8 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
+import org.springframework.util.StringUtils
+import java.time.LocalDate
 
 @Repository
 class InternshipAnnouncementRepositoryImpl(
@@ -22,16 +27,16 @@ class InternshipAnnouncementRepositoryImpl(
         user: User,
         sortBy: String,
         pageable: Pageable,
+        now: LocalDate,
     ): Page<Tuple> {
-        val sort = SortType.from(sortBy)
-        val query = baseQuery(user).orderBy(sort.orderSpecifier)
-
-        val total = query.clone().select(internshipAnnouncement.count()).fetchOne() ?: 0L
         val content =
-            query
+            baseQuery(user)
+                .orderBy(*createOrderSpecifier(sortBy, now))
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
                 .fetch()
+
+        val total = countQuery(null).fetchOne() ?: 0L
 
         return PageImpl(content, pageable, total)
     }
@@ -41,27 +46,51 @@ class InternshipAnnouncementRepositoryImpl(
         filter: Filter,
         sortBy: String,
         pageable: Pageable,
+        now: LocalDate,
     ): Page<Tuple> {
         val workingPeriod = filter.workingPeriod().toInternshipWorkingPeriod()
         val year = InternshipAnnouncementYear.from(filter.startDate().filterYear.value)
         val month = InternshipAnnouncementMonth.from(filter.startDate().filterMonth.value)
 
-        val sort = SortType.from(sortBy)
-        val query =
-            baseQuery(user)
-                .where(
-                    internshipAnnouncement.workingPeriod.eq(workingPeriod),
-                    internshipAnnouncement.startDate.year.eq(year),
-                    internshipAnnouncement.startDate.month.eq(month),
-                )
-                .orderBy(sort.orderSpecifier)
+        val whereClause =
+            internshipAnnouncement.workingPeriod.eq(workingPeriod)
+                .and(internshipAnnouncement.startDate.year.eq(year))
+                .and(internshipAnnouncement.startDate.month.eq(month))
 
-        val total = query.clone().select(internshipAnnouncement.count()).fetchOne() ?: 0L
         val content =
-            query
+            baseQuery(user)
+                .where(whereClause)
+                .orderBy(*createOrderSpecifier(sortBy, now))
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
                 .fetch()
+
+        val total =
+            queryFactory
+                .select(internshipAnnouncement.count())
+                .from(internshipAnnouncement)
+                .where(whereClause)
+                .fetchOne() ?: 0L
+
+        return PageImpl(content, pageable, total)
+    }
+
+    override fun findByKeywordWithScrapInfo(
+        user: User,
+        keyword: String?,
+        sortBy: String,
+        pageable: Pageable,
+        now: LocalDate,
+    ): Page<Tuple> {
+        val content =
+            baseQuery(user)
+                .where(keywordContains(keyword))
+                .orderBy(*createOrderSpecifier(sortBy, now))
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .fetch()
+
+        val total = countQuery(keyword).fetchOne() ?: 0L
 
         return PageImpl(content, pageable, total)
     }
@@ -75,5 +104,39 @@ class InternshipAnnouncementRepositoryImpl(
                 scrap.internshipAnnouncement.eq(internshipAnnouncement)
                     .and(scrap.user.eq(user)),
             )
+    }
+
+    private fun keywordContains(keyword: String?): BooleanExpression? {
+        if (!StringUtils.hasText(keyword)) {
+            return null
+        }
+        return internshipAnnouncement.title.value.containsIgnoreCase(keyword)
+            .or(internshipAnnouncement.company.name.value.containsIgnoreCase(keyword))
+    }
+
+    private fun createOrderSpecifier(
+        sortBy: String,
+        now: LocalDate,
+    ): Array<OrderSpecifier<*>> {
+        val sort = SortType.from(sortBy)
+
+        if (sort == SortType.DEADLINE_SOON) {
+            val deadlineOrder =
+                CaseBuilder()
+                    .`when`(internshipAnnouncement.internshipAnnouncementDeadline.value.lt(now))
+                    .then(1)
+                    .otherwise(0)
+                    .asc()
+            return arrayOf(deadlineOrder, sort.orderSpecifier)
+        }
+
+        return arrayOf(sort.orderSpecifier)
+    }
+
+    private fun countQuery(keyword: String?): JPAQuery<Long> {
+        return queryFactory
+            .select(internshipAnnouncement.count())
+            .from(internshipAnnouncement)
+            .where(keywordContains(keyword))
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
@@ -1,0 +1,44 @@
+package com.terning.server.kotlin.ui.api
+
+import com.terning.server.kotlin.application.search.SearchService
+import com.terning.server.kotlin.application.search.dto.SearchPageResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/search")
+class SearchController(
+    private val searchService: SearchService,
+) {
+    @GetMapping
+    fun search(
+        // TODO: @AuthenticationPrincipal userId: Long,
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "DEADLINE_SOON") sortBy: String,
+        @PageableDefault(size = 10) pageable: Pageable,
+    ): ResponseEntity<ApiResponse<SearchPageResponse>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        val response =
+            searchService.search(
+                userId = userId,
+                keyword = keyword,
+                sortBy = sortBy,
+                pageable = pageable,
+            )
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "검색에 성공했습니다.",
+                result = response,
+            ),
+        )
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/application/home/HomeServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/home/HomeServiceTest.kt
@@ -49,6 +49,7 @@ class HomeServiceTest {
     private lateinit var user: User
     private val pageable = PageRequest.of(0, 10)
     private val sortBy = "recent"
+    private lateinit var now: LocalDate
 
     @BeforeEach
     fun setUp() {
@@ -58,8 +59,9 @@ class HomeServiceTest {
         scrapRepository = mockk(relaxed = true)
         user = mockk()
         val fixedInstant = Instant.parse("2025-06-08T00:00:00Z")
-        clock = Clock.fixed(fixedInstant, ZoneId.systemDefault())
+        clock = Clock.fixed(fixedInstant, ZoneId.of("Asia/Seoul"))
         service = HomeService(internshipRepository, userRepository, filterRepository, scrapRepository, clock)
+        now = LocalDate.now(clock)
     }
 
     @Nested
@@ -93,7 +95,7 @@ class HomeServiceTest {
             every { userRepository.findById(userId) } returns Optional.of(user)
             every { filterRepository.findLatestByUser(user) } returns filter
             every {
-                internshipRepository.findAllInternshipsWithScrapInfo(user, sortBy, pageable)
+                internshipRepository.findAllInternshipsWithScrapInfo(user, sortBy, pageable, now)
             } returns PageImpl(listOf(tuple))
 
             // when
@@ -147,8 +149,8 @@ class HomeServiceTest {
             every {
                 scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(
                     userId = userId,
-                    start = LocalDate.now(clock),
-                    end = LocalDate.now(clock).plusDays(7),
+                    start = now,
+                    end = now.plusDays(7),
                 )
             } returns emptyList()
 
@@ -165,25 +167,18 @@ class HomeServiceTest {
         @DisplayName("마감 임박 스크랩 공고를 성공적으로 조회한다")
         fun returnsUpcomingDeadlineScrapsSuccessfully() {
             // given
-            val announcement = mockk<InternshipAnnouncement>(relaxed = true)
-            val scrap = mockk<Scrap>(relaxed = true)
-            val startDate = LocalDate.now(clock)
-            val endDate = startDate.plusDays(7)
+            val scrap =
+                createMockScrap(
+                    announcementId = 1L,
+                    title = "마감 임박 공고",
+                    deadline = now.plusDays(5),
+                    hexColor = "#FF5733",
+                )
 
-            every { announcement.id } returns 1L
-            every { announcement.company.logoUrl.value } returns "http://logo.url/logo.png"
-            every { announcement.company.name.value } returns "터닝 기업"
-            every { announcement.title.value } returns "마감 임박 공고"
-            every { announcement.workingPeriod.toString() } returns "3개월"
-            every { announcement.internshipAnnouncementDeadline.value } returns LocalDate.now(clock).plusDays(5)
-            every { announcement.startDate.year.value } returns 2025
-            every { announcement.startDate.month.value } returns 7
-            every { scrap.internshipAnnouncement } returns announcement
-            every { scrap.hexColor() } returns "#FF5733"
             every { userRepository.existsById(userId) } returns true
             every { scrapRepository.existsByUserId(userId) } returns true
             every {
-                scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(userId, startDate, endDate)
+                scrapRepository.findScrapsByUserIdAndDeadlineBetweenOrderByDeadline(userId, now, now.plusDays(7))
             } returns listOf(scrap)
 
             // when
@@ -196,7 +191,6 @@ class HomeServiceTest {
 
             val detail = response.scraps.first()
             assertEquals(1L, detail.internshipAnnouncementId)
-            assertEquals("터닝 기업", detail.companyInfo)
             assertEquals("마감 임박 공고", detail.title)
             assertEquals("D-5", detail.dDay)
             assertEquals(true, detail.isScrapped)
@@ -207,6 +201,7 @@ class HomeServiceTest {
     private fun createMockInternship(
         id: Long,
         title: String,
+        deadline: LocalDate = LocalDate.of(2025, 12, 31),
     ): InternshipAnnouncement {
         return mockk {
             every { this@mockk.id } returns id
@@ -218,6 +213,28 @@ class HomeServiceTest {
                     category = CompanyCategory.from("기타"),
                     logoUrl = CompanyLogoUrl.from("https://logo.com"),
                 )
+            every { this@mockk.internshipAnnouncementDeadline } returns
+                mockk {
+                    every { value } returns deadline
+                }
+            every { this@mockk.startDate } returns
+                mockk {
+                    every { year.value } returns 2025
+                    every { month.value } returns 8
+                }
+        }
+    }
+
+    private fun createMockScrap(
+        announcementId: Long,
+        title: String,
+        deadline: LocalDate,
+        hexColor: String,
+    ): Scrap {
+        val announcement = createMockInternship(announcementId, title, deadline)
+        return mockk {
+            every { internshipAnnouncement } returns announcement
+            every { this@mockk.hexColor() } returns hexColor
         }
     }
 

--- a/src/test/kotlin/com/terning/server/kotlin/application/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/search/SearchServiceTest.kt
@@ -1,0 +1,166 @@
+package com.terning.server.kotlin.application.search
+
+import com.querydsl.core.Tuple
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
+import com.terning.server.kotlin.domain.internshipAnnouncement.QInternshipAnnouncement.internshipAnnouncement
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.CompanyLogoUrl
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipAnnouncementDeadline
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipTitle
+import com.terning.server.kotlin.domain.internshipAnnouncement.vo.InternshipWorkingPeriod
+import com.terning.server.kotlin.domain.scrap.QScrap.scrap
+import com.terning.server.kotlin.domain.scrap.vo.Color
+import com.terning.server.kotlin.domain.user.User
+import com.terning.server.kotlin.domain.user.UserRepository
+import com.terning.server.kotlin.domain.user.exception.UserErrorCode
+import com.terning.server.kotlin.domain.user.exception.UserException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Optional
+
+class SearchServiceTest {
+    private lateinit var internshipAnnouncementRepository: InternshipAnnouncementRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var clock: Clock
+    private lateinit var service: SearchService
+
+    private val userId = 1L
+    private lateinit var user: User
+    private val pageable = PageRequest.of(0, 10)
+    private lateinit var now: LocalDate
+
+    @BeforeEach
+    fun setUp() {
+        internshipAnnouncementRepository = mockk(relaxed = true)
+        userRepository = mockk(relaxed = true)
+        val fixedInstant = Instant.parse("2025-06-15T00:00:00Z")
+        clock = Clock.fixed(fixedInstant, ZoneId.of("Asia/Seoul"))
+        service = SearchService(internshipAnnouncementRepository, userRepository, clock)
+        user = mockk()
+        now = LocalDate.now(clock)
+    }
+
+    @Nested
+    @DisplayName("search 메소드는")
+    inner class Search {
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 UserException을 던진다")
+        fun `it throws exception when user not found`() {
+            // given
+            every { userRepository.findById(userId) } returns Optional.empty()
+
+            // when & then
+            val exception =
+                assertThrows<UserException> {
+                    service.search(userId, "키워드", "recent", pageable)
+                }
+            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("검색 결과가 없으면 빈 페이지를 반환한다")
+        fun `it returns empty page when no results found`() {
+            // given
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every {
+                internshipAnnouncementRepository.findByKeywordWithScrapInfo(
+                    user,
+                    "없는 키워드",
+                    "recent",
+                    pageable,
+                    now,
+                )
+            } returns PageImpl(emptyList())
+
+            // when
+            val response = service.search(userId, "없는 키워드", "recent", pageable)
+
+            // then
+            assertEquals(0, response.totalCount)
+            assertEquals(0, response.announcements.size)
+        }
+
+        @Test
+        @DisplayName("검색에 성공하면 DTO로 변환된 페이지를 반환한다")
+        fun `it returns mapped dto page on success`() {
+            // given
+            val keyword = "네이버"
+            val sortBy = "DEADLINE_SOON"
+            val deadline = now.plusDays(10)
+
+            val announcement = createMockInternship(1L, "네이버웹툰 BE 개발 인턴", deadline)
+            val tuple = createMockTuple(announcement, 2L, Color.PURPLE)
+
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every {
+                internshipAnnouncementRepository.findByKeywordWithScrapInfo(
+                    user,
+                    keyword,
+                    sortBy,
+                    pageable,
+                    now,
+                )
+            } returns PageImpl(listOf(tuple))
+
+            // when
+            val response = service.search(userId, keyword, sortBy, pageable)
+
+            // then
+            assertEquals(1, response.totalCount)
+            assertEquals(1, response.announcements.size)
+
+            val resultDto = response.announcements.first()
+            assertEquals(1L, resultDto.internshipAnnouncementId)
+            assertEquals("네이버웹툰 BE 개발 인턴", resultDto.title)
+            assertEquals(true, resultDto.isScrapped)
+            assertEquals(Color.PURPLE.toHexString(), resultDto.color)
+            assertEquals("D-10", resultDto.dDay)
+        }
+    }
+
+    private fun createMockInternship(
+        id: Long,
+        title: String,
+        deadline: LocalDate,
+    ): InternshipAnnouncement {
+        return mockk {
+            every { this@mockk.id } returns id
+            every { this@mockk.title } returns InternshipTitle.from(title)
+            every { this@mockk.internshipAnnouncementDeadline } returns InternshipAnnouncementDeadline.from(deadline)
+            every { this@mockk.workingPeriod } returns InternshipWorkingPeriod.from(3)
+            every { this@mockk.company } returns
+                mockk {
+                    every { logoUrl } returns CompanyLogoUrl.from("http://logo.url/logo.png")
+                }
+            every { this@mockk.startDate } returns
+                mockk {
+                    every { year.value } returns 2025
+                    every { month.value } returns 7
+                }
+        }
+    }
+
+    private fun createMockTuple(
+        internship: InternshipAnnouncement,
+        scrapId: Long?,
+        scrapColor: Color?,
+    ): Tuple {
+        return mockk {
+            every { get(internshipAnnouncement) } returns internship
+            every { get(scrap.id) } returns scrapId
+            every { get(scrap.color) } returns scrapColor
+        }
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
@@ -1,0 +1,116 @@
+package com.terning.server.kotlin.ui.api
+
+import com.ninjasquad.springmockk.MockkBean
+import com.terning.server.kotlin.application.search.SearchService
+import com.terning.server.kotlin.application.search.dto.SearchAnnouncementResponse
+import com.terning.server.kotlin.application.search.dto.SearchPageResponse
+import io.mockk.every
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@WebMvcTest(SearchController::class)
+@ActiveProfiles("test")
+class SearchControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var searchService: SearchService
+
+    @Test
+    @DisplayName("키워드로 공고를 검색하고 성공적으로 결과를 반환한다")
+    fun searchSuccessfully() {
+        // given
+        val userId = 1L
+        val keyword = "네이버"
+        val sortBy = "DEADLINE_SOON"
+        val pageable = PageRequest.of(0, 10)
+
+        val searchResponse =
+            SearchPageResponse(
+                totalPages = 1,
+                totalCount = 1,
+                hasNext = false,
+                announcements =
+                    listOf(
+                        SearchAnnouncementResponse(
+                            internshipAnnouncementId = 10L,
+                            companyImage = "https://naver.com/logo.png",
+                            dDay = "D-10",
+                            title = "[네이버] 백엔드 개발 인턴 모집",
+                            workingPeriod = "3개월",
+                            isScrapped = true,
+                            color = "#FFFFFF",
+                            deadline = "2025년 6월 26일",
+                            startYearMonth = "2025년 7월",
+                        ),
+                    ),
+            )
+
+        every { searchService.search(userId, keyword, sortBy, pageable) } returns searchResponse
+
+        // when & then
+        mockMvc.get("/api/v1/search") {
+            param("keyword", keyword)
+            param("sortBy", sortBy)
+            param("page", pageable.pageNumber.toString())
+            param("size", pageable.pageSize.toString())
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.status") { value(200) }
+            jsonPath("$.message") { value("검색에 성공했습니다.") }
+            jsonPath("$.result.totalCount") { value(1) }
+            jsonPath("$.result.announcements[0].internshipAnnouncementId") { value(10) }
+            jsonPath("$.result.announcements[0].title") { value("[네이버] 백엔드 개발 인턴 모집") }
+            jsonPath("$.result.announcements[0].isScrapped") { value(true) }
+        }
+    }
+
+    @Test
+    @DisplayName("파라미터 없이 요청 시 기본값으로 검색하고 결과를 반환한다")
+    fun searchWithDefaultParameters() {
+        // given
+        val userId = 1L
+        val pageable = PageRequest.of(0, 10)
+
+        val searchResponse =
+            SearchPageResponse(
+                totalPages = 1,
+                totalCount = 1,
+                hasNext = false,
+                announcements =
+                    listOf(
+                        SearchAnnouncementResponse(
+                            internshipAnnouncementId = 11L,
+                            companyImage = "https://kakao.com/logo.png",
+                            dDay = "D-5",
+                            title = "[카카오] 프론트엔드 개발 인턴 모집",
+                            workingPeriod = "6개월",
+                            isScrapped = false,
+                            color = null,
+                            deadline = "2025년 6월 21일",
+                            startYearMonth = "2025년 8월",
+                        ),
+                    ),
+            )
+
+        every { searchService.search(userId, null, "DEADLINE_SOON", pageable) } returns searchResponse
+
+        // when & then
+        mockMvc.get("/api/v1/search").andExpect {
+            status { isOk() }
+            jsonPath("$.status") { value(200) }
+            jsonPath("$.message") { value("검색에 성공했습니다.") }
+            jsonPath("$.result.totalCount") { value(1) }
+            jsonPath("$.result.announcements[0].internshipAnnouncementId") { value(11) }
+            jsonPath("$.result.announcements[0].title") { value("[카카오] 프론트엔드 개발 인턴 모집") }
+            jsonPath("$.result.announcements[0].isScrapped") { value(false) }
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- 인턴십 공고를 키워드로 검색하는 API(`GET /api/v1/search`)를 구현했습니다.
- 검색 API는 `keyword`, `sortBy`(정렬 기준), `pageable`(페이지네이션) 파라미터를 지원합니다.
- 검색 기능 구현을 위해 `SearchController`, `SearchService`, `DTO`를 추가하고, `Repository` 계층에 키워드 검색 로직을 구현했습니다.
- '마감 임박순' 정렬 시, 이미 마감된 공고가 뒤로 정렬되도록 쿼리 로직을 개선했습니다.
- `SearchService`와 `SearchController`에 대한 단위/통합 테스트 코드를 작성했습니다.
- 기존 `HomeService`의 시간 의존적 로직에 `Clock`을 적용하여 테스트 용이성을 개선하는 리팩토링을 함께 진행했습니다.

# 💭 Thoughts
- 시간에 의존적인 로직(D-day 계산, 마감순 정렬)의 테스트 용이성을 확보하기 위해 `Clock`을 주입하고, 서비스 계층에서 생성한 `now`를 Repository까지 전달하는 구조로 설계했습니다.
- '마감순 정렬' 시, 사용자가 이미 마감된 공고를 먼저 보는 경험을 방지하고자, 마감된 공고는 뒤로 정렬되도록 `CASE` 문을 사용하여 쿼리를 개선했습니다.
- 반복되는 쿼리 로직과 테스트 데이터 생성 코드를 각각 헬퍼 메서드로 분리하여 코드의 가독성과 재사용성을 높이고자 했습니다.

# ✅ Testing Result  
![스크린샷 2025-06-16 오후 11 07 06](https://github.com/user-attachments/assets/286925f7-af03-470f-8fc6-3a41447ec438)
![스크린샷 2025-06-16 오후 11 07 06](https://github.com/user-attachments/assets/286925f7-af03-470f-8fc6-3a41447ec438)


# 🗂 Related Issue  
- closed #113 
