### PR TITLE
[✨feat] 조회수 많은 공고 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
@@ -2,6 +2,8 @@ package com.terning.server.kotlin.application.search
 
 import com.terning.server.kotlin.application.search.dto.SearchAnnouncementResponse
 import com.terning.server.kotlin.application.search.dto.SearchPageResponse
+import com.terning.server.kotlin.application.search.dto.ViewCountAnnouncementResponse
+import com.terning.server.kotlin.application.search.dto.ViewCountResponse
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncementRepository
 import com.terning.server.kotlin.domain.user.UserRepository
 import com.terning.server.kotlin.domain.user.exception.UserErrorCode
@@ -43,5 +45,20 @@ class SearchService(
         val announcementResponse = announcementTuples.map { tuple -> SearchAnnouncementResponse.of(tuple, clock) }
 
         return SearchPageResponse.from(announcementResponse)
+    }
+
+    fun getMostViewedAnnouncements(userId: Long): ViewCountResponse {
+        if (!userRepository.existsById(userId)) {
+            throw UserException(UserErrorCode.USER_NOT_FOUND)
+        }
+
+        val currentDate = LocalDate.now(clock)
+        val announcements = internshipAnnouncementRepository.findTop5ByViews(currentDate)
+
+        val responses = announcements.map {
+            ViewCountAnnouncementResponse.from(it)
+        }
+
+        return ViewCountResponse(announcements = responses)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
@@ -55,9 +55,10 @@ class SearchService(
         val currentDate = LocalDate.now(clock)
         val announcements = internshipAnnouncementRepository.findTop5ByViews(currentDate)
 
-        val responses = announcements.map {
-            ViewCountAnnouncementResponse.from(it)
-        }
+        val responses =
+            announcements.map {
+                ViewCountAnnouncementResponse.from(it)
+            }
 
         return ViewCountResponse(announcements = responses)
     }

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ViewCountResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ViewCountResponse.kt
@@ -3,7 +3,7 @@ package com.terning.server.kotlin.application.search.dto
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
 
 data class ViewCountResponse(
-    val announcements: List<ViewCountAnnouncementResponse>
+    val announcements: List<ViewCountAnnouncementResponse>,
 )
 
 data class ViewCountAnnouncementResponse(
@@ -16,7 +16,7 @@ data class ViewCountAnnouncementResponse(
             return ViewCountAnnouncementResponse(
                 internshipAnnouncementId = announcement.id!!,
                 companyImage = announcement.company.logoUrl.value,
-                title = announcement.title.value
+                title = announcement.title.value,
             )
         }
     }

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ViewCountResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ViewCountResponse.kt
@@ -1,0 +1,23 @@
+package com.terning.server.kotlin.application.search.dto
+
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
+
+data class ViewCountResponse(
+    val announcements: List<ViewCountAnnouncementResponse>
+)
+
+data class ViewCountAnnouncementResponse(
+    val internshipAnnouncementId: Long,
+    val companyImage: String,
+    val title: String,
+) {
+    companion object {
+        fun from(announcement: InternshipAnnouncement): ViewCountAnnouncementResponse {
+            return ViewCountAnnouncementResponse(
+                internshipAnnouncementId = announcement.id!!,
+                companyImage = announcement.company.logoUrl.value,
+                title = announcement.title.value
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryCustom.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryCustom.kt
@@ -30,4 +30,6 @@ interface InternshipAnnouncementRepositoryCustom {
         pageable: Pageable,
         now: LocalDate,
     ): Page<Tuple>
+
+    fun findTop5ByViews(now: LocalDate): List<InternshipAnnouncement>
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryImpl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryImpl.kt
@@ -100,7 +100,7 @@ class InternshipAnnouncementRepositoryImpl(
             .selectFrom(internshipAnnouncement)
             .where(
                 internshipAnnouncement.internshipAnnouncementDeadline.value.goe(now),
-                internshipAnnouncement.internshipAnnouncementDeadline.value.loe(now.plusDays(30))
+                internshipAnnouncement.internshipAnnouncementDeadline.value.loe(now.plusDays(30)),
             )
             .orderBy(internshipAnnouncement.internshipAnnouncementViewCount.value.desc())
             .limit(5)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryImpl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryImpl.kt
@@ -95,6 +95,18 @@ class InternshipAnnouncementRepositoryImpl(
         return PageImpl(content, pageable, total)
     }
 
+    override fun findTop5ByViews(now: LocalDate): List<InternshipAnnouncement> {
+        return queryFactory
+            .selectFrom(internshipAnnouncement)
+            .where(
+                internshipAnnouncement.internshipAnnouncementDeadline.value.goe(now),
+                internshipAnnouncement.internshipAnnouncementDeadline.value.loe(now.plusDays(30))
+            )
+            .orderBy(internshipAnnouncement.internshipAnnouncementViewCount.value.desc())
+            .limit(5)
+            .fetch()
+    }
+
     private fun baseQuery(user: User): JPAQuery<Tuple> {
         return queryFactory
             .select(internshipAnnouncement, scrap.id, scrap.color)

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
@@ -2,6 +2,7 @@ package com.terning.server.kotlin.ui.api
 
 import com.terning.server.kotlin.application.search.SearchService
 import com.terning.server.kotlin.application.search.dto.SearchPageResponse
+import com.terning.server.kotlin.application.search.dto.ViewCountResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
@@ -37,6 +38,23 @@ class SearchController(
             ApiResponse.success(
                 status = HttpStatus.OK,
                 message = "검색에 성공했습니다.",
+                result = response,
+            ),
+        )
+    }
+
+    @GetMapping("/views")
+    fun getMostViewedAnnouncements(
+        // TODO: @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<ViewCountResponse>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        val response = searchService.getMostViewedAnnouncements(userId)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "탐색 > 조회수 많은 공고를 조회하는데 성공했습니다",
                 result = response,
             ),
         )

--- a/src/test/kotlin/com/terning/server/kotlin/application/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/search/SearchServiceTest.kt
@@ -130,6 +130,61 @@ class SearchServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("getMostViewedAnnouncements 메소드는")
+    inner class GetMostViewedAnnouncements {
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 UserException을 던진다")
+        fun `it throws exception when user not found`() {
+            // given
+            every { userRepository.existsById(userId) } returns false
+
+            // when & then
+            val exception =
+                assertThrows<UserException> {
+                    service.getMostViewedAnnouncements(userId)
+                }
+            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("조회수 많은 공고가 없으면 빈 리스트를 반환한다")
+        fun `it returns empty list when no announcements found`() {
+            // given
+            every { userRepository.existsById(userId) } returns true
+            every { internshipAnnouncementRepository.findTop5ByViews(now) } returns emptyList()
+
+            // when
+            val response = service.getMostViewedAnnouncements(userId)
+
+            // then
+            assertEquals(0, response.announcements.size)
+        }
+
+        @Test
+        @DisplayName("조회수 많은 공고 조회에 성공하면 DTO 리스트를 반환한다")
+        fun `it returns dto list on success`() {
+            // given
+            every { userRepository.existsById(userId) } returns true
+
+            val announcement1 = createMockInternship(1L, "인기 공고 1", now)
+            val announcement2 = createMockInternship(2L, "인기 공고 2", now)
+            val mockAnnouncements = listOf(announcement1, announcement2)
+
+            every { internshipAnnouncementRepository.findTop5ByViews(now) } returns mockAnnouncements
+
+            // when
+            val response = service.getMostViewedAnnouncements(userId)
+
+            // then
+            assertEquals(2, response.announcements.size)
+            assertEquals(1L, response.announcements[0].internshipAnnouncementId)
+            assertEquals("인기 공고 1", response.announcements[0].title)
+            assertEquals(2L, response.announcements[1].internshipAnnouncementId)
+            assertEquals("인기 공고 2", response.announcements[1].title)
+        }
+    }
+
     private fun createMockInternship(
         id: Long,
         title: String,

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
@@ -4,6 +4,8 @@ import com.ninjasquad.springmockk.MockkBean
 import com.terning.server.kotlin.application.search.SearchService
 import com.terning.server.kotlin.application.search.dto.SearchAnnouncementResponse
 import com.terning.server.kotlin.application.search.dto.SearchPageResponse
+import com.terning.server.kotlin.application.search.dto.ViewCountAnnouncementResponse
+import com.terning.server.kotlin.application.search.dto.ViewCountResponse
 import io.mockk.every
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -112,5 +114,41 @@ class SearchControllerTest {
             jsonPath("$.result.announcements[0].title") { value("[카카오] 프론트엔드 개발 인턴 모집") }
             jsonPath("$.result.announcements[0].isScrapped") { value(false) }
         }
+    }
+
+    @Test
+    @DisplayName("조회수 많은 공고를 성공적으로 조회한다")
+    fun getMostViewedAnnouncementsSuccessfully() {
+        // given
+        val userId = 1L
+        val viewCountResponse =
+            ViewCountResponse(
+                announcements =
+                    listOf(
+                        ViewCountAnnouncementResponse(
+                            internshipAnnouncementId = 23L,
+                            companyImage = "image_url_1",
+                            title = "인기 공고 1",
+                        ),
+                        ViewCountAnnouncementResponse(
+                            internshipAnnouncementId = 3L,
+                            companyImage = "image_url_2",
+                            title = "인기 공고 2",
+                        ),
+                    ),
+            )
+
+        every { searchService.getMostViewedAnnouncements(userId) } returns viewCountResponse
+
+        // when & then
+        mockMvc.get("/api/v1/search/views")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.status") { value(200) }
+                jsonPath("$.message") { value("탐색 > 조회수 많은 공고를 조회하는데 성공했습니다") }
+                jsonPath("$.result.announcements.size()") { value(2) }
+                jsonPath("$.result.announcements[0].internshipAnnouncementId") { value(23L) }
+                jsonPath("$.result.announcements[0].title") { value("인기 공고 1") }
+            }
     }
 }


### PR DESCRIPTION
# 📄 Work Description

탐색 화면의 **'조회수 많은 공고 조회'** API (`GET /api/v1/search/views`)를 구현했습니다.

  - 현재를 기준으로 30일 내에 마감되는, 만료되지 않은 공고 중 조회수가 가장 높은 **상위 5개**를 조회합니다.
  - 기능 구현에 필요한 `Controller`, `Service`, `Repository`, `DTO`를 각각 추가 및 수정했습니다.

# 💭 Thoughts

  - 조회수 공고를 필터링하는 기준이 '현재 날짜'에 의존하므로, 테스트의 일관성을 위해 `Clock`을 주입하여 시간을 제어하는 구조를 사용했습니다.
  - API 명세서의 요구사항(`30일 내 마감`, `만료되지 않음`, `조회수 내림차순`, `상위 5개`)을 `Repository`의 조회 쿼리에 명확하게 반영하여, 비즈니스 로직을 한눈에 파악할 수 있도록 구현했습니다.


# ✅ Testing Result  
![스크린샷 2025-06-16 오후 11 33 13](https://github.com/user-attachments/assets/eccae25e-82a7-4c63-9dcd-d7de723983e7)


# 🗂 Related Issue  
- closed #115 

