### PR TITLE
[✨feat] 스크랩 수 많은 공고 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
@@ -1,5 +1,7 @@
 package com.terning.server.kotlin.application.search
 
+import com.terning.server.kotlin.application.search.dto.ScrapCountAnnouncementResponse
+import com.terning.server.kotlin.application.search.dto.ScrapCountResponse
 import com.terning.server.kotlin.application.search.dto.SearchAnnouncementResponse
 import com.terning.server.kotlin.application.search.dto.SearchPageResponse
 import com.terning.server.kotlin.application.search.dto.ViewCountAnnouncementResponse
@@ -63,7 +65,7 @@ class SearchService(
         return ViewCountResponse(announcements = responses)
     }
 
-    fun getMostScrappedAnnouncements(userId: Long): ViewCountResponse {
+    fun getMostScrappedAnnouncements(userId: Long): ScrapCountResponse {
         if (!userRepository.existsById(userId)) {
             throw UserException(UserErrorCode.USER_NOT_FOUND)
         }
@@ -72,9 +74,9 @@ class SearchService(
 
         val responses =
             announcements.map {
-                ViewCountAnnouncementResponse.from(it)
+                ScrapCountAnnouncementResponse.from(it)
             }
 
-        return ViewCountResponse(announcements = responses)
+        return ScrapCountResponse(announcements = responses)
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
@@ -62,4 +62,19 @@ class SearchService(
 
         return ViewCountResponse(announcements = responses)
     }
+
+    fun getMostScrappedAnnouncements(userId: Long): ViewCountResponse {
+        if (!userRepository.existsById(userId)) {
+            throw UserException(UserErrorCode.USER_NOT_FOUND)
+        }
+
+        val announcements = internshipAnnouncementRepository.findTop5ByScraps()
+
+        val responses =
+            announcements.map {
+                ViewCountAnnouncementResponse.from(it)
+            }
+
+        return ViewCountResponse(announcements = responses)
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ScrapCountResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ScrapCountResponse.kt
@@ -1,6 +1,8 @@
 package com.terning.server.kotlin.application.search.dto
 
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
+import com.terning.server.kotlin.domain.internshipAnnouncement.exception.InternshipAnnouncementErrorCode
+import com.terning.server.kotlin.domain.internshipAnnouncement.exception.InternshipAnnouncementException
 
 data class ScrapCountResponse(
     val announcements: List<ScrapCountAnnouncementResponse>,
@@ -13,8 +15,10 @@ data class ScrapCountAnnouncementResponse(
 ) {
     companion object {
         fun from(announcement: InternshipAnnouncement): ScrapCountAnnouncementResponse {
+            val announcementId = announcement.id
+                ?: throw InternshipAnnouncementException(InternshipAnnouncementErrorCode.ANNOUNCEMENT_ID_NULL)
             return ScrapCountAnnouncementResponse(
-                internshipAnnouncementId = announcement.id!!,
+                internshipAnnouncementId = announcementId,
                 companyImage = announcement.company.logoUrl.value,
                 title = announcement.title.value,
             )

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ScrapCountResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ScrapCountResponse.kt
@@ -1,0 +1,23 @@
+package com.terning.server.kotlin.application.search.dto
+
+import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
+
+data class ScrapCountResponse(
+    val announcements: List<ScrapCountAnnouncementResponse>,
+)
+
+data class ScrapCountAnnouncementResponse(
+    val internshipAnnouncementId: Long,
+    val companyImage: String,
+    val title: String,
+) {
+    companion object {
+        fun from(announcement: InternshipAnnouncement): ScrapCountAnnouncementResponse {
+            return ScrapCountAnnouncementResponse(
+                internshipAnnouncementId = announcement.id!!,
+                companyImage = announcement.company.logoUrl.value,
+                title = announcement.title.value,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ScrapCountResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/dto/ScrapCountResponse.kt
@@ -15,8 +15,9 @@ data class ScrapCountAnnouncementResponse(
 ) {
     companion object {
         fun from(announcement: InternshipAnnouncement): ScrapCountAnnouncementResponse {
-            val announcementId = announcement.id
-                ?: throw InternshipAnnouncementException(InternshipAnnouncementErrorCode.ANNOUNCEMENT_ID_NULL)
+            val announcementId =
+                announcement.id
+                    ?: throw InternshipAnnouncementException(InternshipAnnouncementErrorCode.ANNOUNCEMENT_ID_NULL)
             return ScrapCountAnnouncementResponse(
                 internshipAnnouncementId = announcementId,
                 companyImage = announcement.company.logoUrl.value,

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryCustom.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryCustom.kt
@@ -32,4 +32,6 @@ interface InternshipAnnouncementRepositoryCustom {
     ): Page<Tuple>
 
     fun findTop5ByViews(now: LocalDate): List<InternshipAnnouncement>
+
+    fun findTop5ByScraps(): List<InternshipAnnouncement>
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryImpl.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/InternshipAnnouncementRepositoryImpl.kt
@@ -107,6 +107,14 @@ class InternshipAnnouncementRepositoryImpl(
             .fetch()
     }
 
+    override fun findTop5ByScraps(): List<InternshipAnnouncement> {
+        return queryFactory
+            .selectFrom(internshipAnnouncement)
+            .orderBy(internshipAnnouncement.internshipAnnouncementScrapCount.value.desc())
+            .limit(5)
+            .fetch()
+    }
+
     private fun baseQuery(user: User): JPAQuery<Tuple> {
         return queryFactory
             .select(internshipAnnouncement, scrap.id, scrap.color)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/exception/InternshipAnnouncementErrorCode.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/internshipAnnouncement/exception/InternshipAnnouncementErrorCode.kt
@@ -27,4 +27,5 @@ enum class InternshipAnnouncementErrorCode(
     NOT_FOUND_ANNOUNCEMENT_EXCEPTION(HttpStatus.NOT_FOUND, "인턴십 공고를 찾을 수 없습니다."),
     INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 방식입니다."),
     INVALID_START_DATE(HttpStatus.BAD_REQUEST, "시작 날짜 형식이 잘못되었습니다. 'YYYY-MM' 형식이어야 합니다."),
+    ANNOUNCEMENT_ID_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "공고 ID가 존재하지 않습니다."),
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
@@ -59,4 +59,21 @@ class SearchController(
             ),
         )
     }
+
+    @GetMapping("/scraps")
+    fun getMostScrappedAnnouncements(
+        // TODO: @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<ViewCountResponse>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        val response = searchService.getMostScrappedAnnouncements(userId)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다",
+                result = response,
+            ),
+        )
+    }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
@@ -1,6 +1,7 @@
 package com.terning.server.kotlin.ui.api
 
 import com.terning.server.kotlin.application.search.SearchService
+import com.terning.server.kotlin.application.search.dto.ScrapCountResponse
 import com.terning.server.kotlin.application.search.dto.SearchPageResponse
 import com.terning.server.kotlin.application.search.dto.ViewCountResponse
 import org.springframework.data.domain.Pageable
@@ -63,7 +64,7 @@ class SearchController(
     @GetMapping("/scraps")
     fun getMostScrappedAnnouncements(
         // TODO: @AuthenticationPrincipal userId: Long,
-    ): ResponseEntity<ApiResponse<ViewCountResponse>> {
+    ): ResponseEntity<ApiResponse<ScrapCountResponse>> {
         val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
 
         val response = searchService.getMostScrappedAnnouncements(userId)

--- a/src/test/kotlin/com/terning/server/kotlin/application/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/search/SearchServiceTest.kt
@@ -185,6 +185,61 @@ class SearchServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("getMostScrappedAnnouncements 메소드는")
+    inner class GetMostScrappedAnnouncements {
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 UserException을 던진다")
+        fun `it throws exception when user not found`() {
+            // given
+            every { userRepository.existsById(userId) } returns false
+
+            // when & then
+            val exception =
+                assertThrows<UserException> {
+                    service.getMostScrappedAnnouncements(userId)
+                }
+            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("스크랩 많은 공고가 없으면 빈 리스트를 반환한다")
+        fun `it returns empty list when no announcements found`() {
+            // given
+            every { userRepository.existsById(userId) } returns true
+            every { internshipAnnouncementRepository.findTop5ByScraps() } returns emptyList()
+
+            // when
+            val response = service.getMostScrappedAnnouncements(userId)
+
+            // then
+            assertEquals(0, response.announcements.size)
+        }
+
+        @Test
+        @DisplayName("스크랩 많은 공고 조회에 성공하면 DTO 리스트를 반환한다")
+        fun `it returns dto list on success`() {
+            // given
+            every { userRepository.existsById(userId) } returns true
+
+            val announcement1 = createMockInternship(10L, "스크랩 많은 공고 1", now)
+            val announcement2 = createMockInternship(20L, "스크랩 많은 공고 2", now)
+            val mockAnnouncements = listOf(announcement1, announcement2)
+
+            every { internshipAnnouncementRepository.findTop5ByScraps() } returns mockAnnouncements
+
+            // when
+            val response = service.getMostScrappedAnnouncements(userId)
+
+            // then
+            assertEquals(2, response.announcements.size)
+            assertEquals(10L, response.announcements[0].internshipAnnouncementId)
+            assertEquals("스크랩 많은 공고 1", response.announcements[0].title)
+            assertEquals(20L, response.announcements[1].internshipAnnouncementId)
+            assertEquals("스크랩 많은 공고 2", response.announcements[1].title)
+        }
+    }
+
     private fun createMockInternship(
         id: Long,
         title: String,

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
@@ -151,4 +151,40 @@ class SearchControllerTest {
                 jsonPath("$.result.announcements[0].title") { value("인기 공고 1") }
             }
     }
+
+    @Test
+    @DisplayName("스크랩 많은 공고를 성공적으로 조회한다")
+    fun getMostScrappedAnnouncementsSuccessfully() {
+        // given
+        val userId = 1L
+        val scrapCountResponse =
+            ViewCountResponse(
+                announcements =
+                    listOf(
+                        ViewCountAnnouncementResponse(
+                            internshipAnnouncementId = 50L,
+                            companyImage = "image_scrap_1",
+                            title = "스크랩 많은 공고 1",
+                        ),
+                        ViewCountAnnouncementResponse(
+                            internshipAnnouncementId = 51L,
+                            companyImage = "image_scrap_2",
+                            title = "스크랩 많은 공고 2",
+                        ),
+                    ),
+            )
+
+        every { searchService.getMostScrappedAnnouncements(userId) } returns scrapCountResponse
+
+        // when & then
+        mockMvc.get("/api/v1/search/scraps")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.status") { value(200) }
+                jsonPath("$.message") { value("탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다") }
+                jsonPath("$.result.announcements.size()") { value(2) }
+                jsonPath("$.result.announcements[0].internshipAnnouncementId") { value(50L) }
+                jsonPath("$.result.announcements[0].title") { value("스크랩 많은 공고 1") }
+            }
+    }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
@@ -2,6 +2,8 @@ package com.terning.server.kotlin.ui.api
 
 import com.ninjasquad.springmockk.MockkBean
 import com.terning.server.kotlin.application.search.SearchService
+import com.terning.server.kotlin.application.search.dto.ScrapCountAnnouncementResponse
+import com.terning.server.kotlin.application.search.dto.ScrapCountResponse
 import com.terning.server.kotlin.application.search.dto.SearchAnnouncementResponse
 import com.terning.server.kotlin.application.search.dto.SearchPageResponse
 import com.terning.server.kotlin.application.search.dto.ViewCountAnnouncementResponse
@@ -158,15 +160,15 @@ class SearchControllerTest {
         // given
         val userId = 1L
         val scrapCountResponse =
-            ViewCountResponse(
+            ScrapCountResponse(
                 announcements =
                     listOf(
-                        ViewCountAnnouncementResponse(
+                        ScrapCountAnnouncementResponse(
                             internshipAnnouncementId = 50L,
                             companyImage = "image_scrap_1",
                             title = "스크랩 많은 공고 1",
                         ),
-                        ViewCountAnnouncementResponse(
+                        ScrapCountAnnouncementResponse(
                             internshipAnnouncementId = 51L,
                             companyImage = "image_scrap_2",
                             title = "스크랩 많은 공고 2",


### PR DESCRIPTION

# 📄 Work Description
탐색 화면의 **'스크랩 많은 공고 조회'** API (`GET /api/v1/search/scraps`)를 구현했습니다.

- 스크랩 수가 가장 높은 상위 5개의 공고를 조회합니다.
- 기능 구현에 필요한 `Controller`, `Service`, `dto`, `Repository` 로직을 각각 추가 및 수정했습니다.

# 💭 Thoughts
- 이번 기능은 별도의 필터링 조건 없이 스크랩 수 기준으로만 정렬하면 되었기 때문에, `Repository`의 조회 쿼리를 간결하게 작성할 수 있었습니다.

# ✅ Testing Result  
![스크린샷 2025-06-16 오후 11 46 28](https://github.com/user-attachments/assets/17c39f23-fba0-4e33-ab8f-adf0fdf834dd)

# 🗂 Related Issue  
- closed #117 

