### PR TITLE
[✨feat] 광고 배너 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/SearchService.kt
@@ -1,5 +1,7 @@
 package com.terning.server.kotlin.application.search
 
+import com.terning.server.kotlin.application.search.dto.Banner
+import com.terning.server.kotlin.application.search.dto.BannersView
 import com.terning.server.kotlin.application.search.dto.ScrapCountAnnouncementResponse
 import com.terning.server.kotlin.application.search.dto.ScrapCountResponse
 import com.terning.server.kotlin.application.search.dto.SearchAnnouncementResponse
@@ -78,5 +80,30 @@ class SearchService(
             }
 
         return ScrapCountResponse(announcements = responses)
+    }
+
+    fun getBanners(userId: Long): BannersView {
+        if (!userRepository.existsById(userId)) {
+            throw UserException(UserErrorCode.USER_NOT_FOUND)
+        }
+        return BannersView(banners = banners)
+    }
+
+    companion object {
+        private val banners =
+            listOf(
+                Banner(
+                    imageUrl = "https://bit.ly/3Ytoq8p",
+                    link = "https://forms.gle/4btEwEbUQ3JSjTKP7",
+                ),
+                Banner(
+                    imageUrl = "https://bit.ly/4ea2jtn",
+                    link = "https://www.instagram.com/terning_official/",
+                ),
+                Banner(
+                    imageUrl = "https://bit.ly/4hoZSWR",
+                    link = "https://www.instagram.com/terning_official/",
+                ),
+            )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/search/dto/BannersView.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/search/dto/BannersView.kt
@@ -1,0 +1,10 @@
+package com.terning.server.kotlin.application.search.dto
+
+data class BannersView(
+    val banners: List<Banner>,
+)
+
+data class Banner(
+    val imageUrl: String,
+    val link: String,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
@@ -1,6 +1,7 @@
 package com.terning.server.kotlin.ui.api
 
 import com.terning.server.kotlin.application.search.SearchService
+import com.terning.server.kotlin.application.search.dto.BannersView
 import com.terning.server.kotlin.application.search.dto.ScrapCountResponse
 import com.terning.server.kotlin.application.search.dto.SearchPageResponse
 import com.terning.server.kotlin.application.search.dto.ViewCountResponse
@@ -73,6 +74,23 @@ class SearchController(
             ApiResponse.success(
                 status = HttpStatus.OK,
                 message = "탐색 > 스크랩 수 많은 공고를 조회하는데 성공했습니다",
+                result = response,
+            ),
+        )
+    }
+
+    @GetMapping("/banners")
+    fun getBanners(
+        // TODO: @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<BannersView>> {
+        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
+
+        val response = searchService.getBanners(userId)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "탐색 뷰 > 배너 조회에 성공했습니다",
                 result = response,
             ),
         )

--- a/src/test/kotlin/com/terning/server/kotlin/application/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/search/SearchServiceTest.kt
@@ -240,6 +240,39 @@ class SearchServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("getBanners 메소드는")
+    inner class GetBanners {
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 UserException을 던진다")
+        fun `it throws exception when user not found`() {
+            // given
+            every { userRepository.existsById(userId) } returns false
+
+            // when & then
+            val exception =
+                assertThrows<UserException> {
+                    service.getBanners(userId)
+                }
+            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("사용자가 존재하면 하드코딩된 배너 리스트를 반환한다")
+        fun `it returns hardcoded banner list on success`() {
+            // given
+            every { userRepository.existsById(userId) } returns true
+
+            // when
+            val response = service.getBanners(userId)
+
+            // then
+            assertEquals(3, response.banners.size)
+            assertEquals("https://bit.ly/3Ytoq8p", response.banners[0].imageUrl)
+            assertEquals("https://forms.gle/4btEwEbUQ3JSjTKP7", response.banners[0].link)
+        }
+    }
+
     private fun createMockInternship(
         id: Long,
         title: String,

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
@@ -2,6 +2,8 @@ package com.terning.server.kotlin.ui.api
 
 import com.ninjasquad.springmockk.MockkBean
 import com.terning.server.kotlin.application.search.SearchService
+import com.terning.server.kotlin.application.search.dto.Banner
+import com.terning.server.kotlin.application.search.dto.BannersView
 import com.terning.server.kotlin.application.search.dto.ScrapCountAnnouncementResponse
 import com.terning.server.kotlin.application.search.dto.ScrapCountResponse
 import com.terning.server.kotlin.application.search.dto.SearchAnnouncementResponse
@@ -187,6 +189,40 @@ class SearchControllerTest {
                 jsonPath("$.result.announcements.size()") { value(2) }
                 jsonPath("$.result.announcements[0].internshipAnnouncementId") { value(50L) }
                 jsonPath("$.result.announcements[0].title") { value("스크랩 많은 공고 1") }
+            }
+    }
+
+    @Test
+    @DisplayName("배너를 성공적으로 조회한다")
+    fun getBannersSuccessfully() {
+        // given
+        val userId = 1L
+        val bannersView =
+            BannersView(
+                banners =
+                    listOf(
+                        Banner(
+                            imageUrl = "https://bit.ly/3Ytoq8p",
+                            link = "https://forms.gle/4btEwEbUQ3JSjTKP7",
+                        ),
+                        Banner(
+                            imageUrl = "https://bit.ly/4ea2jtn",
+                            link = "https://www.instagram.com/terning_official/",
+                        ),
+                    ),
+            )
+
+        every { searchService.getBanners(userId) } returns bannersView
+
+        // when & then
+        mockMvc.get("/api/v1/search/banners")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.status") { value(200) }
+                jsonPath("$.message") { value("탐색 뷰 > 배너 조회에 성공했습니다") }
+                jsonPath("$.result.banners.size()") { value(2) }
+                jsonPath("$.result.banners[0].imageUrl") { value("https://bit.ly/3Ytoq8p") }
+                jsonPath("$.result.banners[0].link") { value("https://forms.gle/4btEwEbUQ3JSjTKP7") }
             }
     }
 }


### PR DESCRIPTION
# 📄 Work Description
탐색 화면의 상단 **배너를 조회하는 API** (`GET /api/v1/search/banners`)를 구현했습니다.

- 기획팀으로부터 전달받은 고정된 배너 목록을 우선순위에 맞게 반환합니다.
- 기능 구현에 필요한 `Controller`, `Service`, `DTO` 로직을 `search` 도메인 내에 추가했습니다.

# 💭 Thoughts
- 배너 기능은 '탐색' 화면에 위치하지만, '검색'과는 역할과 책임이 다른 독립적인 기능입니다. 처음에는 별도의 `banner` 도메인(패키지)으로 분리하는 것을 고려했습니다.
- 하지만 현재 애플리케이션의 규모와 기능의 복잡도를 고려했을 때, 탐색 화면 관련 기능들을 `search` 도메인으로 통합하여 관리하는 것이 초기 개발 단계에서 더 효율적이라고 판단했습니다.
- 만약 추후 배너 기능이 다른 화면에서 재사용되거나 로직이 복잡해진다면, 그 시점에 `banner` 도메인으로 분리하는 리팩토링을 진행하는 것이 좋을 것 같습니다.

# ✅ Testing Result  
![스크린샷 2025-06-17 오전 12 13 11](https://github.com/user-attachments/assets/cb0857dd-9154-4843-8c04-28ebd2d4c5e4)


# 🗂 Related Issue  
- closed #119 

