### PR TITLE
[✨feat] 회원가입 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -2,12 +2,19 @@ package com.terning.server.kotlin.application.auth
 
 import com.terning.server.kotlin.application.auth.dto.SignInRequest
 import com.terning.server.kotlin.application.auth.dto.SignInResponse
+import com.terning.server.kotlin.application.auth.dto.SignUpRequest
+import com.terning.server.kotlin.application.auth.dto.SignUpResponse
 import com.terning.server.kotlin.application.auth.social.SocialAuthServiceManager
+import com.terning.server.kotlin.domain.auth.Auth
 import com.terning.server.kotlin.domain.auth.AuthRepository
 import com.terning.server.kotlin.domain.auth.vo.AuthId
 import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.RefreshToken
 import com.terning.server.kotlin.domain.common.security.jwt.application.JwtTokenManager
+import com.terning.server.kotlin.domain.user.User
+import com.terning.server.kotlin.domain.user.UserRepository
+import com.terning.server.kotlin.domain.user.exception.UserErrorCode
+import com.terning.server.kotlin.domain.user.exception.UserException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,7 +24,9 @@ class AuthService(
     private val socialAuthServiceManager: SocialAuthServiceManager,
     private val jwtTokenManager: JwtTokenManager,
     private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
 ) {
+    @Transactional
     fun signInUser(
         socialAccessToken: String,
         signInRequest: SignInRequest,
@@ -57,5 +66,42 @@ class AuthService(
             authType = authType,
             userId = user.id,
         )
+    }
+
+    @Transactional
+    fun signUpUser(
+        authId: String,
+        signUpRequest: SignUpRequest,
+    ): SignUpResponse {
+        val tokenWithoutBearer = authId.removePrefix("$BEARER ").trim()
+        val user =
+            User.of(
+                name = signUpRequest.name,
+                profile = signUpRequest.profileImage,
+            )
+        val auth =
+            Auth.of(
+                user = user,
+                authId = AuthId.from(tokenWithoutBearer),
+                authType = AuthType.from(signUpRequest.authType),
+                refreshToken = RefreshToken.from(null),
+            )
+
+        userRepository.save(user)
+        authRepository.save(auth)
+
+        val token = jwtTokenManager.generateToken(user)
+
+        auth.updateRefreshToken(RefreshToken.from(token.refreshToken))
+
+        return SignUpResponse.from(
+            token = token,
+            userId = user.id ?: throw UserException(UserErrorCode.USER_NOT_FOUND),
+            authType = auth.authType(),
+        )
+    }
+
+    companion object {
+        private const val BEARER = "Bearer"
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -94,6 +94,8 @@ class AuthService(
 
         auth.updateRefreshToken(RefreshToken.from(token.refreshToken))
 
+        // TODO : ApplicationEventPublisher 구현 by 이유빈
+
         return SignUpResponse.from(
             token = token,
             userId = user.id ?: throw UserException(UserErrorCode.USER_NOT_FOUND),

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -94,7 +94,7 @@ class AuthService(
 
         auth.updateRefreshToken(RefreshToken.from(token.refreshToken))
 
-        // TODO : ApplicationEventPublisher 구현 by 이유빈
+        // TODO : ApplicationEventPublisher 구현
 
         return SignUpResponse.from(
             token = token,

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/SignInResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/SignInResponse.kt
@@ -18,8 +18,8 @@ data class SignInResponse(
             userId: Long?,
             authType: AuthType,
             fcmTokenReissueRequired: Boolean = false,
-        ): SignInResponse {
-            return SignInResponse(
+        ): SignInResponse =
+            SignInResponse(
                 accessToken = token?.accessToken,
                 refreshToken = token?.refreshToken,
                 userId = userId,
@@ -27,6 +27,5 @@ data class SignInResponse(
                 authType = authType.name,
                 fcmTokenReissueRequired = fcmTokenReissueRequired,
             )
-        }
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/SignUpRequest.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/SignUpRequest.kt
@@ -1,0 +1,8 @@
+package com.terning.server.kotlin.application.auth.dto
+
+data class SignUpRequest(
+    val name: String,
+    val profileImage: String,
+    val authType: String,
+    val fcmToken: String,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/SignUpResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/SignUpResponse.kt
@@ -1,0 +1,8 @@
+package com.terning.server.kotlin.application.auth.dto
+
+data class SignUpResponse (
+    val accessToken: String,
+    val refreshToken: String,
+    val userId: Long,
+    val authType: String,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/SignUpResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/SignUpResponse.kt
@@ -1,8 +1,25 @@
 package com.terning.server.kotlin.application.auth.dto
 
-data class SignUpResponse (
+import com.terning.server.kotlin.domain.auth.vo.AuthType
+import com.terning.server.kotlin.domain.auth.vo.Token
+
+data class SignUpResponse(
     val accessToken: String,
     val refreshToken: String,
     val userId: Long,
     val authType: String,
-)
+) {
+    companion object {
+        fun from(
+            token: Token,
+            userId: Long,
+            authType: AuthType,
+        ): SignUpResponse =
+            SignUpResponse(
+                accessToken = token.accessToken,
+                refreshToken = token.refreshToken,
+                userId = userId,
+                authType = authType.name,
+            )
+    }
+}

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -52,7 +52,7 @@ class AuthController(
         return ResponseEntity.ok(
             ApiResponse.success(
                 status = HttpStatus.OK,
-                message = "회원가입에 성공하였습니다",
+                message = "회원가입에 성공하였습니다.",
                 result = response,
             ),
         )

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -42,18 +42,19 @@ class AuthController(
     fun signUp(
         @RequestHeader("Authorization") authId: String,
         @RequestBody signUpRequest: SignUpRequest,
-    ) : ResponseEntity<ApiResponse<SignUpResponse>>{
-        val response = authService.signUpUser(
-            authId = authId,
-            signUpRequest = signUpRequest
-        )
+    ): ResponseEntity<ApiResponse<SignUpResponse>> {
+        val response =
+            authService.signUpUser(
+                authId = authId,
+                signUpRequest = signUpRequest,
+            )
 
         return ResponseEntity.ok(
             ApiResponse.success(
                 status = HttpStatus.OK,
                 message = "회원가입에 성공하였습니다",
                 result = response,
-            )
+            ),
         )
     }
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -3,6 +3,8 @@ package com.terning.server.kotlin.ui.api
 import com.terning.server.kotlin.application.auth.AuthService
 import com.terning.server.kotlin.application.auth.dto.SignInRequest
 import com.terning.server.kotlin.application.auth.dto.SignInResponse
+import com.terning.server.kotlin.application.auth.dto.SignUpRequest
+import com.terning.server.kotlin.application.auth.dto.SignUpResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -33,6 +35,25 @@ class AuthController(
                 message = "로그인에 성공했습니다.",
                 result = response,
             ),
+        )
+    }
+
+    @PostMapping("/sign-up")
+    fun signUp(
+        @RequestHeader("Authorization") authId: String,
+        @RequestBody signUpRequest: SignUpRequest,
+    ) : ResponseEntity<ApiResponse<SignUpResponse>>{
+        val response = authService.signUpUser(
+            authId = authId,
+            signUpRequest = signUpRequest
+        )
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "회원가입에 성공하였습니다",
+                result = response,
+            )
         )
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -2,6 +2,7 @@ package com.terning.server.kotlin.application.auth
 
 import com.terning.server.kotlin.application.auth.dto.SignInRequest
 import com.terning.server.kotlin.application.auth.dto.SignInResponse
+import com.terning.server.kotlin.application.auth.dto.SignUpRequest
 import com.terning.server.kotlin.application.auth.social.SocialAuthProvider
 import com.terning.server.kotlin.application.auth.social.SocialAuthServiceManager
 import com.terning.server.kotlin.domain.auth.Auth
@@ -12,6 +13,8 @@ import com.terning.server.kotlin.domain.auth.vo.RefreshToken
 import com.terning.server.kotlin.domain.auth.vo.Token
 import com.terning.server.kotlin.domain.common.security.jwt.application.JwtTokenManager
 import com.terning.server.kotlin.domain.user.User
+import com.terning.server.kotlin.domain.user.UserRepository
+import com.terning.server.kotlin.domain.user.vo.ProfileImage
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -19,21 +22,27 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class AuthServiceTest {
     private val socialAuthServiceManager: SocialAuthServiceManager = mockk()
     private val jwtTokenManager: JwtTokenManager = mockk()
     private val authRepository: AuthRepository = mockk()
+    private val userRepository: UserRepository = mockk()
     private lateinit var authService: AuthService
 
-    private val socialAccessToken = "socialAccessToken"
+    private val accessToken = "accessToken"
+    private val refreshToken = "refreshToken"
     private val signInRequest = SignInRequest(authType = "KAKAO", fcmToken = "")
     private val authType = AuthType.KAKAO
     private val authId = "123456"
     private val kakaoProvider = mockk<SocialAuthProvider>()
+    private val profileImage = ProfileImage.LUCKY.value
 
     @BeforeEach
     fun setup() {
@@ -42,67 +51,108 @@ class AuthServiceTest {
                 socialAuthServiceManager = socialAuthServiceManager,
                 jwtTokenManager = jwtTokenManager,
                 authRepository = authRepository,
+                userRepository = userRepository,
             )
     }
 
-    @Test
-    fun `회원이 존재하지 않으면 null 토큰과 null 유저아이디를 반환한다`() {
-        // given
-        every { socialAuthServiceManager.getAuthService(authType) } returns kakaoProvider
-        every { kakaoProvider.getAuthId(socialAccessToken) } returns authId
-        every { authRepository.findByAuthIdAndAuthType(AuthId.from(authId), authType) } returns null
+    @Nested
+    @DisplayName("signIn 메소드는")
+    inner class SignIn {
+        @Test
+        fun `회원이 존재하지 않으면 null 토큰과 null 유저아이디를 반환한다`() {
+            // given
+            every { socialAuthServiceManager.getAuthService(authType) } returns kakaoProvider
+            every { kakaoProvider.getAuthId(accessToken) } returns authId
+            every { authRepository.findByAuthIdAndAuthType(AuthId.from(authId), authType) } returns null
 
-        // when
-        val result: SignInResponse =
-            authService.signInUser(
-                socialAccessToken = socialAccessToken,
-                signInRequest = signInRequest,
-            )
+            // when
+            val result: SignInResponse =
+                authService.signInUser(
+                    socialAccessToken = accessToken,
+                    signInRequest = signInRequest,
+                )
 
-        // then
-        assertNull(result.accessToken)
-        assertNull(result.userId)
-        assertEquals(authId, result.authId)
-        assertEquals(authType.name, result.authType)
+            // then
+            assertNull(result.accessToken)
+            assertNull(result.userId)
+            assertEquals(authId, result.authId)
+            assertEquals(authType.name, result.authType)
+        }
+
+        @Test
+        fun `회원이 존재하면 토큰과 유저아이디를 반환한다`() {
+            // given
+            val authIdVo = AuthId.from(authId)
+
+            val user = mockk<User>(relaxed = true)
+            val auth =
+                spyk(
+                    Auth.of(
+                        user = user,
+                        authId = authIdVo,
+                        authType = authType,
+                        refreshToken = RefreshToken.from("old-token"),
+                    ),
+                )
+            val token =
+                Token(
+                    accessToken = "newAccess",
+                    refreshToken = "newRefresh",
+                )
+
+            every { socialAuthServiceManager.getAuthService(authType) } returns kakaoProvider
+            every { kakaoProvider.getAuthId(accessToken) } returns authId
+            every { authRepository.findByAuthIdAndAuthType(authIdVo, authType) } returns auth
+            every { jwtTokenManager.generateToken(user) } returns token
+            every { auth.updateRefreshToken(any()) } just Runs
+
+            // when
+            val result = authService.signInUser(accessToken, signInRequest)
+
+            // then
+            assertEquals("newAccess", result.accessToken)
+            assertEquals("newRefresh", result.refreshToken)
+            assertEquals(authId, result.authId)
+            assertEquals(authType.name, result.authType)
+            assertEquals(user.id, result.userId)
+
+            verify { auth.updateRefreshToken(RefreshToken.from("newRefresh")) }
+        }
     }
 
-    @Test
-    fun `회원이 존재하면 토큰과 유저아이디를 반환한다`() {
-        // given
-        val authIdVo = AuthId.from(authId)
+    @Nested
+    @DisplayName("signUp 메소드는")
+    inner class SignUp {
+        @Test
+        fun `회원가입 시 토큰과 유저 정보를 반환한다`() {
+            // given
+            val request =
+                SignUpRequest(
+                    name = "이유빈",
+                    profileImage = profileImage,
+                    authType = authType.value,
+                    fcmToken = "",
+                )
+            val token = Token(accessToken = accessToken, refreshToken = refreshToken)
 
-        val user = mockk<User>(relaxed = true)
-        val auth =
-            spyk(
-                Auth.of(
-                    user = user,
-                    authId = authIdVo,
-                    authType = authType,
-                    refreshToken = RefreshToken.from("old-token"),
-                ),
-            )
-        val token =
-            Token(
-                accessToken = "newAccess",
-                refreshToken = "newRefresh",
-            )
+            every { userRepository.save(any()) } answers {
+                val user = firstArg<User>()
+                val field = User::class.java.getDeclaredField("id")
+                field.isAccessible = true
+                field.set(user, 1L)
+                user
+            }
+            every { authRepository.save(any()) } returns mockk()
+            every { jwtTokenManager.generateToken(any()) } returns token
 
-        every { socialAuthServiceManager.getAuthService(authType) } returns kakaoProvider
-        every { kakaoProvider.getAuthId(socialAccessToken) } returns authId
-        every { authRepository.findByAuthIdAndAuthType(authIdVo, authType) } returns auth
-        every { jwtTokenManager.generateToken(user) } returns token
-        every { auth.updateRefreshToken(any()) } just Runs
+            // when
+            val response = authService.signUpUser(authId = authId, signUpRequest = request)
 
-        // when
-        val result = authService.signInUser(socialAccessToken, signInRequest)
-
-        // then
-        assertEquals("newAccess", result.accessToken)
-        assertEquals("newRefresh", result.refreshToken)
-        assertEquals(authId, result.authId)
-        assertEquals(authType.name, result.authType)
-        assertEquals(user.id, result.userId)
-
-        verify { auth.updateRefreshToken(RefreshToken.from("newRefresh")) }
+            // then
+            assertNotNull(response)
+            assertEquals("accessToken", response.accessToken)
+            assertEquals("refreshToken", response.refreshToken)
+            assertEquals("KAKAO", response.authType)
+        }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -5,6 +5,8 @@ import com.ninjasquad.springmockk.MockkBean
 import com.terning.server.kotlin.application.auth.AuthService
 import com.terning.server.kotlin.application.auth.dto.SignInRequest
 import com.terning.server.kotlin.application.auth.dto.SignInResponse
+import com.terning.server.kotlin.application.auth.dto.SignUpRequest
+import com.terning.server.kotlin.application.auth.dto.SignUpResponse
 import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.Token
 import io.mockk.every
@@ -69,6 +71,44 @@ class AuthControllerTest {
             jsonPath("$.result.userId") { value(1) }
             jsonPath("$.result.accessToken") { value("accessToken") }
             jsonPath("$.result.refreshToken") { value("refreshToken") }
+        }
+    }
+
+    @Test
+    fun `유저를 회원가입한다`() {
+        // given
+        val request =
+            SignUpRequest(
+                name = "이유빈",
+                profileImage = "LUCKY",
+                authType = "KAKAO",
+                fcmToken = "fcmToken",
+            )
+        val response =
+            SignUpResponse(
+                accessToken = "accessToken",
+                refreshToken = "refreshToken",
+                userId = 1L,
+                authType = "KAKAO",
+            )
+
+        every { authService.signUpUser(any(), any()) } returns response
+
+        // when & then
+        mockMvc.post("/api/v1/auth/sign-up") {
+            contentType = MediaType.APPLICATION_JSON
+            accept = MediaType.APPLICATION_JSON
+            header("Authorization", "Bearer 123456")
+            content = objectMapper.writeValueAsString(request)
+            with(csrf())
+        }.andExpect {
+            status { isOk() }
+            content { contentType(MediaType.APPLICATION_JSON) }
+            jsonPath("$.message") { value("회원가입에 성공하였습니다.") }
+            jsonPath("$.result.accessToken") { value("accessToken") }
+            jsonPath("$.result.refreshToken") { value("refreshToken") }
+            jsonPath("$.result.userId") { value(1L) }
+            jsonPath("$.result.authType") { value("KAKAO") }
         }
     }
 }


### PR DESCRIPTION
# 📄 Work Description  
- 회원가입 API 구현했습니다. 
- 회원가입의 경우 `User`와 `Auth` 엔티티를 사용하기 때문에 각각의 레포지토리에 값을 저장해주었습니다.
- Service와 Controller에 대한 테스트 코드를 작성하였습니다. Service 테스트의 경우, 실제 JPA에서는 id를 자동 할당해주지만 테스트에서는 불가능하여 오류가 발생하더라구요. 따라서 직접 id 필드 값을 넣어주는 방향으로 구현하였습니다.

# 💭 Thoughts 
- 이번 PR을 작성하면서 같이 고민이 되었던 부분은 "`사용자 필터링 정보 생성 API`"의 위치입니다. 
    - 해당 API의 URL은 `auth/filter`로 되어 있는데 auth 패키지 안에 넣기에는 기존에 있던 filter 패키지와 강하게 연결되어 있어서 이를 URL만 보고 auth로 넣기가 애매하더라구요..
    -  물론 해당 API가 사용자를 생성하는 auth의 과정 중 하나이긴 하지만 필터링을 생성한다는 성격이 더 강한 것 같아서 filter 패키지에 그대로 두었습니다..!
- 회원가입 시 기존 프로젝트에서는 `ApplicationEventPublisher`를 사용하고 있었지만, 지금은 API 개발에 집중하는 게 좋을 것 같아서 본 PR에서는 구현하지 않았습니다!
    - 제가 찾아본 바로는 `ApplicationEventPublisher`는 다른 작업을 비동기적으로 처리해주는 것 같던데 기존 프로젝트에서도 사용자가 가입하면 알림을 띄우거나 총 가입자 수를 세거나 등등 작업을 하는 것 같더라구요 이 이해가 맞을까요?

# ✅ Testing Result  

<img width="396" alt="image" src="https://github.com/user-attachments/assets/e468c0c9-7d01-4f5e-a2c4-d3feef9bf43f" />

<img width="381" alt="image" src="https://github.com/user-attachments/assets/c3b5318e-5115-4ccd-8dfc-e5603cd5d0ab" />

# 🗂 Related Issue  
- closed #123
