### PR TITLE
[✨feat] 로그아웃 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -104,7 +104,7 @@ class AuthService(
     }
 
     @Transactional
-    fun singOut(userId: Long) {
+    fun signOut(userId: Long) {
         val auth = authRepository.findByUserId(userId)
 
         auth.resetRefreshToken()

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -7,6 +7,8 @@ import com.terning.server.kotlin.application.auth.dto.SignUpResponse
 import com.terning.server.kotlin.application.auth.social.SocialAuthServiceManager
 import com.terning.server.kotlin.domain.auth.Auth
 import com.terning.server.kotlin.domain.auth.AuthRepository
+import com.terning.server.kotlin.domain.auth.exception.AuthErrorCode
+import com.terning.server.kotlin.domain.auth.exception.AuthException
 import com.terning.server.kotlin.domain.auth.vo.AuthId
 import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.RefreshToken
@@ -105,7 +107,7 @@ class AuthService(
 
     @Transactional
     fun signOut(userId: Long) {
-        val auth = authRepository.findByUserId(userId)
+        val auth = authRepository.findByUserId(userId) ?: throw AuthException(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)
 
         auth.resetRefreshToken()
     }

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -103,6 +103,13 @@ class AuthService(
         )
     }
 
+    @Transactional
+    fun singOut(userId: Long) {
+        val auth = authRepository.findByUserId(userId)
+
+        auth.resetRefreshToken()
+    }
+
     companion object {
         private const val BEARER = "Bearer"
     }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -10,5 +10,5 @@ interface AuthRepository : JpaRepository<Auth, Long> {
         authType: AuthType,
     ): Auth?
 
-    fun findByUserId(userId: Long): Auth
+    fun findByUserId(userId: Long): Auth?
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -9,4 +9,6 @@ interface AuthRepository : JpaRepository<Auth, Long> {
         authId: AuthId,
         authType: AuthType,
     ): Auth?
+
+    fun findByUserId(userId: Long): Auth
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -63,7 +63,7 @@ class AuthController(
     fun signOut(
         @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<Unit>> {
-        authService.singOut(userId)
+        authService.signOut(userId)
 
         return ResponseEntity.ok(
             ApiResponse.success(

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -7,6 +7,7 @@ import com.terning.server.kotlin.application.auth.dto.SignUpRequest
 import com.terning.server.kotlin.application.auth.dto.SignUpResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -54,6 +55,21 @@ class AuthController(
                 status = HttpStatus.OK,
                 message = "회원가입에 성공하였습니다.",
                 result = response,
+            ),
+        )
+    }
+
+    @PostMapping("/logout")
+    fun singOut(
+        @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<Unit>>  {
+        authService.singOut(userId)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "로그아웃에 성공하였습니다.",
+                result = Unit,
             ),
         )
     }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -62,7 +62,7 @@ class AuthController(
     @PostMapping("/logout")
     fun singOut(
         @AuthenticationPrincipal userId: Long,
-    ): ResponseEntity<ApiResponse<Unit>>  {
+    ): ResponseEntity<ApiResponse<Unit>> {
         authService.singOut(userId)
 
         return ResponseEntity.ok(

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -60,7 +60,7 @@ class AuthController(
     }
 
     @PostMapping("/logout")
-    fun singOut(
+    fun signOut(
         @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<Unit>> {
         authService.singOut(userId)

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -167,7 +167,7 @@ class AuthServiceTest {
             every { authRepository.findByUserId(userId) } returns mockAuth
 
             // when
-            authService.singOut(userId)
+            authService.signOut(userId)
 
             // then
             verify { mockAuth.resetRefreshToken() }

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -155,4 +155,22 @@ class AuthServiceTest {
             assertEquals("KAKAO", response.authType)
         }
     }
+
+    @Nested
+    @DisplayName("signOut 메소드는")
+    inner class SignOut {
+        @Test
+        fun `로그아웃 시 유저의 리프레시 토큰을 초기화한다`() {
+            // given
+            val userId = 1L
+            val mockAuth = mockk<Auth>(relaxed = true)
+            every { authRepository.findByUserId(userId) } returns mockAuth
+
+            // when
+            authService.singOut(userId)
+
+            // then
+            verify { mockAuth.resetRefreshToken() }
+        }
+    }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -124,7 +124,7 @@ class AuthControllerTest {
         val authentication = UsernamePasswordAuthenticationToken(1L, null, emptyList())
         SecurityContextHolder.getContext().authentication = authentication
 
-        every { authService.singOut(1L) } just Runs
+        every { authService.signOut(1L) } just Runs
 
         // when & then
         mockMvc.post("/api/v1/auth/logout")
@@ -133,6 +133,6 @@ class AuthControllerTest {
                 jsonPath("$.message") { value("로그아웃에 성공하였습니다.") }
             }
 
-        verify { authService.singOut(1L) }
+        verify { authService.signOut(1L) }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -120,11 +120,13 @@ class AuthControllerTest {
 
     @Test
     fun `유저를 로그아웃한다`() {
+        // given
         val authentication = UsernamePasswordAuthenticationToken(1L, null, emptyList())
         SecurityContextHolder.getContext().authentication = authentication
 
         every { authService.singOut(1L) } just Runs
 
+        // when & then
         mockMvc.post("/api/v1/auth/logout")
             .andExpect {
                 status { isOk() }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -7,21 +7,27 @@ import com.terning.server.kotlin.application.auth.dto.SignInRequest
 import com.terning.server.kotlin.application.auth.dto.SignInResponse
 import com.terning.server.kotlin.application.auth.dto.SignUpRequest
 import com.terning.server.kotlin.application.auth.dto.SignUpResponse
+import com.terning.server.kotlin.config.TestSecurityConfig
 import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.Token
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
-import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(AuthController::class)
-@WithMockUser
+@Import(TestSecurityConfig::class)
 @ActiveProfiles("test")
 class AuthControllerTest {
     @Autowired
@@ -110,5 +116,21 @@ class AuthControllerTest {
             jsonPath("$.result.userId") { value(1L) }
             jsonPath("$.result.authType") { value("KAKAO") }
         }
+    }
+
+    @Test
+    fun `유저를 로그아웃한다`() {
+        val authentication = UsernamePasswordAuthenticationToken(1L, null, emptyList())
+        SecurityContextHolder.getContext().authentication = authentication
+
+        every { authService.singOut(1L) } just Runs
+
+        mockMvc.post("/api/v1/auth/logout")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.message") { value("로그아웃에 성공하였습니다.") }
+            }
+
+        verify { authService.singOut(1L) }
     }
 }


### PR DESCRIPTION
# 📄 Work Description  
- 로그아웃 API 구현했습니다.
- Security가 구현됨에 따라 `@AuthenticationPrincipal`를 넣어주었습니다.
- 이로 인해 Controller 테스트 코드에서는 `SecurityContextHolder`를 수동으로 설정해 주었습니다.

# 💭 Thoughts 
- 이제 `@AuthenticationPrincipal` 쓸 수 있는 거 맞죠?! 이거 리팩토링 한 번에 해도 괜찮을 것 같네요!

# ✅ Testing Result  
<img width="393" alt="image" src="https://github.com/user-attachments/assets/bb75c557-d48b-45ef-acd3-d91bdab7c258" />
<img width="488" alt="image" src="https://github.com/user-attachments/assets/1731ee77-b99b-42fb-8dda-f8b926efc18d" />

# 🗂 Related Issue  
- closed #124
