### PR TITLE
[✨feat] 계정 탈퇴 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -114,8 +114,10 @@ class AuthService(
 
     @Transactional
     fun withdraw(userId: Long) {
-        val auth = authRepository.findByUserId(userId) ?: throw AuthException(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)
-        val user = auth.user
+        val user =
+            userRepository.findById(userId).orElseThrow {
+                UserException(UserErrorCode.USER_NOT_FOUND)
+            }
 
         userRepository.delete(user)
     }

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -112,6 +112,14 @@ class AuthService(
         auth.resetRefreshToken()
     }
 
+    @Transactional
+    fun withdraw(userId: Long) {
+        val auth = authRepository.findByUserId(userId) ?: throw AuthException(AuthErrorCode.NOT_FOUND_USER_EXCEPTION)
+        val user = auth.user
+
+        userRepository.delete(user)
+    }
+
     companion object {
         private const val BEARER = "Bearer"
     }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/user/User.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/user/User.kt
@@ -1,18 +1,24 @@
 package com.terning.server.kotlin.domain.user
 
+import com.terning.server.kotlin.domain.auth.Auth
 import com.terning.server.kotlin.domain.common.BaseRootEntity
+import com.terning.server.kotlin.domain.scrap.Scrap
 import com.terning.server.kotlin.domain.user.vo.ProfileImage
 import com.terning.server.kotlin.domain.user.vo.UserName
 import com.terning.server.kotlin.domain.user.vo.UserState
 import jakarta.persistence.AttributeOverride
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 
 @Entity
@@ -36,6 +42,12 @@ class User private constructor(
     @Enumerated(EnumType.STRING)
     @Column(name = "state", length = 12, nullable = false)
     private var userState: UserState,
+
+    @OneToOne(mappedBy = "user", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY)
+    var auth: Auth? = null,
+
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY)
+    val scraps: MutableList<Scrap> = mutableListOf(),
 ) : BaseRootEntity() {
     fun name(): String = name.value
 

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -78,7 +78,7 @@ class AuthController(
     @DeleteMapping("/withdraw")
     fun withdraw(
         @AuthenticationPrincipal userId: Long,
-    ): ResponseEntity<ApiResponse<Unit>>  {
+    ): ResponseEntity<ApiResponse<Unit>> {
         authService.withdraw(userId)
 
         return ResponseEntity.ok(

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -8,6 +8,7 @@ import com.terning.server.kotlin.application.auth.dto.SignUpResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -69,6 +70,21 @@ class AuthController(
             ApiResponse.success(
                 status = HttpStatus.OK,
                 message = "로그아웃에 성공하였습니다.",
+                result = Unit,
+            ),
+        )
+    }
+
+    @DeleteMapping("/withdraw")
+    fun withdraw(
+        @AuthenticationPrincipal userId: Long,
+    ): ResponseEntity<ApiResponse<Unit>>  {
+        authService.withdraw(userId)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "계정탈퇴에 성공하였습니다.",
                 result = Unit,
             ),
         )

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -187,8 +187,6 @@ class AuthServiceTest {
             every { userRepository.findById(userId) } returns Optional.of(user)
             every { userRepository.delete(user) } just Runs
 
-            every { userRepository.delete(user) } just Runs
-
             // when
             authService.withdraw(userId)
 

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.util.Optional
 
 class AuthServiceTest {
     private val socialAuthServiceManager: SocialAuthServiceManager = mockk()
@@ -182,19 +183,16 @@ class AuthServiceTest {
             // given
             val userId = 1L
             val user = mockk<User>()
-            val auth =
-                mockk<Auth> {
-                    every { this@mockk.user } returns user
-                }
 
-            every { authRepository.findByUserId(userId) } returns auth
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every { userRepository.delete(user) } just Runs
+
             every { userRepository.delete(user) } just Runs
 
             // when
             authService.withdraw(userId)
 
             // then
-            verify(exactly = 1) { authRepository.findByUserId(userId) }
             verify(exactly = 1) { userRepository.delete(user) }
         }
     }

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -176,15 +176,16 @@ class AuthServiceTest {
 
     @Nested
     @DisplayName("withdraw 메소드는")
-    inner class  Withdraw {
+    inner class Withdraw {
         @Test
         fun `회원탈퇴 시 유저의 정보를 지운다`() {
             // given
             val userId = 1L
             val user = mockk<User>()
-            val auth = mockk<Auth> {
-                every { this@mockk.user } returns user
-            }
+            val auth =
+                mockk<Auth> {
+                    every { this@mockk.user } returns user
+                }
 
             every { authRepository.findByUserId(userId) } returns auth
             every { userRepository.delete(user) } just Runs
@@ -195,7 +196,6 @@ class AuthServiceTest {
             // then
             verify(exactly = 1) { authRepository.findByUserId(userId) }
             verify(exactly = 1) { userRepository.delete(user) }
-
         }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -173,4 +173,29 @@ class AuthServiceTest {
             verify { mockAuth.resetRefreshToken() }
         }
     }
+
+    @Nested
+    @DisplayName("withdraw 메소드는")
+    inner class  Withdraw {
+        @Test
+        fun `회원탈퇴 시 유저의 정보를 지운다`() {
+            // given
+            val userId = 1L
+            val user = mockk<User>()
+            val auth = mockk<Auth> {
+                every { this@mockk.user } returns user
+            }
+
+            every { authRepository.findByUserId(userId) } returns auth
+            every { userRepository.delete(user) } just Runs
+
+            // when
+            authService.withdraw(userId)
+
+            // then
+            verify(exactly = 1) { authRepository.findByUserId(userId) }
+            verify(exactly = 1) { userRepository.delete(user) }
+
+        }
+    }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -24,6 +24,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.post
 
 @WebMvcTest(AuthController::class)
@@ -134,5 +135,24 @@ class AuthControllerTest {
             }
 
         verify { authService.signOut(1L) }
+    }
+
+    @Test
+    fun `유저를 탈퇴한다`() {
+        // given
+        val authentication = UsernamePasswordAuthenticationToken(1L, null, emptyList())
+        SecurityContextHolder.getContext().authentication = authentication
+
+        every { authService.withdraw(1L) } just Runs
+
+        // when & then
+        mockMvc.delete("/api/v1/auth/withdraw") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.message") { value("계정탈퇴에 성공하였습니다.") }
+        }
+
+        verify { authService.withdraw(1L) }
     }
 }


### PR DESCRIPTION
# 📄 Work Description  
- 계정 탈퇴 API를 구현했습니다.
- 계정 탈퇴를 위해 userId에 해당하는 정보를 삭제했습니다. 
- Service와 Controller에 해당하는 테스트 코드를 각각 작성했습니다.

# 💭 Thoughts 
- 회원을 삭제한다는 것이 생각보다 큰 고민 거리였는데요..
    - userId에 해당하는 User의 레코드를 삭제한다면, User를 참조하고 있는 Auth와 Scrap은 일명 '고아 객체'가 될 것이라고 생각했습니다.
    - 따라서 같이 삭제를 해 줘야 하는데, 이때 authRepository와 ScrapRepository를 각각 delete 해주는 것이 아니라 JPA의 기능을 활용하기 위해 User와 양방향 관계를 설정해주었습니다.
    - 그리고 `cascade = CascadeType.REMOVE`를 설정해주어 부모 엔티티(User)가 삭제 되면 자식 엔티티(Auth, Scrap)도 삭제되는 속성을 추가하였습니다.
    - 그러면 나머지 엔티티인 Filter, InternshipAnnouncement도 삭제를 해줘야 되나 고민이 되었는데요.. 이들은 User에 대한 정보를 가지고 있는 것이 아니라서 삭제를 하지 않아도 될 것 같아 별다른 조치를 하지 않았습니다.

# ✅ Testing Result  
<img width="487" alt="image" src="https://github.com/user-attachments/assets/7f53da3f-7feb-4d85-ad29-872787c73bd8" />

<img width="483" alt="image" src="https://github.com/user-attachments/assets/a151c0aa-9acf-43f3-abaf-abd999ab6fb2" />


# 🗂 Related Issue  
- closed #133
