### PR TITLE
[✨feat] 토큰 재발급 API 구현

### DIFF
--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -1,6 +1,10 @@
 package com.terning.server.kotlin.application.auth
 
-import com.terning.server.kotlin.application.auth.dto.*
+import com.terning.server.kotlin.application.auth.dto.SignInRequest
+import com.terning.server.kotlin.application.auth.dto.SignInResponse
+import com.terning.server.kotlin.application.auth.dto.SignUpRequest
+import com.terning.server.kotlin.application.auth.dto.SignUpResponse
+import com.terning.server.kotlin.application.auth.dto.TokenReissueResponse
 import com.terning.server.kotlin.application.auth.social.SocialAuthServiceManager
 import com.terning.server.kotlin.domain.auth.Auth
 import com.terning.server.kotlin.domain.auth.AuthRepository
@@ -121,8 +125,9 @@ class AuthService(
 
     @Transactional
     fun tokenReissue(refreshToken: String): TokenReissueResponse {
-        val auth = authRepository.findByRefreshToken(RefreshToken.from(refreshToken))
-            ?: throw AuthException(AuthErrorCode.FAILED_REFRESH_TOKEN_RESET)
+        val auth =
+            authRepository.findByRefreshToken(RefreshToken.from(refreshToken))
+                ?: throw AuthException(AuthErrorCode.FAILED_REFRESH_TOKEN_RESET)
 
         val token = jwtTokenManager.issueAccessToken(auth)
 

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/AuthService.kt
@@ -1,9 +1,6 @@
 package com.terning.server.kotlin.application.auth
 
-import com.terning.server.kotlin.application.auth.dto.SignInRequest
-import com.terning.server.kotlin.application.auth.dto.SignInResponse
-import com.terning.server.kotlin.application.auth.dto.SignUpRequest
-import com.terning.server.kotlin.application.auth.dto.SignUpResponse
+import com.terning.server.kotlin.application.auth.dto.*
 import com.terning.server.kotlin.application.auth.social.SocialAuthServiceManager
 import com.terning.server.kotlin.domain.auth.Auth
 import com.terning.server.kotlin.domain.auth.AuthRepository
@@ -56,7 +53,7 @@ class AuthService(
         }
 
         val user = auth.user
-        val token = jwtTokenManager.generateToken(user)
+        val token = jwtTokenManager.generateToken(auth)
 
         auth.updateRefreshToken(
             newRefreshToken = RefreshToken.from(token.refreshToken),
@@ -92,7 +89,7 @@ class AuthService(
         userRepository.save(user)
         authRepository.save(auth)
 
-        val token = jwtTokenManager.generateToken(user)
+        val token = jwtTokenManager.generateToken(auth)
 
         auth.updateRefreshToken(RefreshToken.from(token.refreshToken))
 
@@ -120,6 +117,18 @@ class AuthService(
             }
 
         userRepository.delete(user)
+    }
+
+    @Transactional
+    fun tokenReissue(refreshToken: String): TokenReissueResponse {
+        val auth = authRepository.findByRefreshToken(RefreshToken.from(refreshToken))
+            ?: throw AuthException(AuthErrorCode.FAILED_REFRESH_TOKEN_RESET)
+
+        val token = jwtTokenManager.issueAccessToken(auth)
+
+        return TokenReissueResponse(
+            accessToken = token.accessToken,
+        )
     }
 
     companion object {

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/TokenReissueResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/TokenReissueResponse.kt
@@ -1,5 +1,5 @@
 package com.terning.server.kotlin.application.auth.dto
 
-data class TokenReissueResponse (
+data class TokenReissueResponse(
     val accessToken: String,
 )

--- a/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/TokenReissueResponse.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/application/auth/dto/TokenReissueResponse.kt
@@ -1,0 +1,5 @@
+package com.terning.server.kotlin.application.auth.dto
+
+data class TokenReissueResponse (
+    val accessToken: String,
+)

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/AuthRepository.kt
@@ -2,6 +2,7 @@ package com.terning.server.kotlin.domain.auth
 
 import com.terning.server.kotlin.domain.auth.vo.AuthId
 import com.terning.server.kotlin.domain.auth.vo.AuthType
+import com.terning.server.kotlin.domain.auth.vo.RefreshToken
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AuthRepository : JpaRepository<Auth, Long> {
@@ -11,4 +12,6 @@ interface AuthRepository : JpaRepository<Auth, Long> {
     ): Auth?
 
     fun findByUserId(userId: Long): Auth?
+
+    fun findByRefreshToken(refreshToken: RefreshToken): Auth?
 }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/auth/vo/Token.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/auth/vo/Token.kt
@@ -2,5 +2,5 @@ package com.terning.server.kotlin.domain.auth.vo
 
 data class Token(
     val accessToken: String,
-    val refreshToken: String,
+    val refreshToken: String = "",
 )

--- a/src/main/kotlin/com/terning/server/kotlin/domain/common/security/jwt/application/JwtTokenManager.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/common/security/jwt/application/JwtTokenManager.kt
@@ -1,9 +1,9 @@
 package com.terning.server.kotlin.domain.common.security.jwt.application
 
+import com.terning.server.kotlin.domain.auth.Auth
 import com.terning.server.kotlin.domain.auth.vo.Token
 import com.terning.server.kotlin.domain.common.config.ValueConfig
 import com.terning.server.kotlin.domain.common.security.jwt.auth.AuthenticationTokenFactory
-import com.terning.server.kotlin.domain.user.User
 import org.springframework.stereotype.Service
 
 @Service
@@ -11,8 +11,8 @@ class JwtTokenManager(
     private val jwtTokenIssuer: JwtTokenIssuer,
     private val valueConfig: ValueConfig,
 ) {
-    fun generateToken(user: User): Token {
-        val authentication = AuthenticationTokenFactory.create(user)
+    fun generateToken(auth: Auth): Token {
+        val authentication = AuthenticationTokenFactory.create(auth)
         val accessTokenExpiration = valueConfig.accessTokenExpired
         val refreshTokenExpiration = valueConfig.refreshTokenExpired
 
@@ -26,6 +26,19 @@ class JwtTokenManager(
                 jwtTokenIssuer.generateToken(
                     authentication = authentication,
                     expiration = refreshTokenExpiration,
+                ),
+        )
+    }
+
+    fun issueAccessToken(auth: Auth): Token {
+        val authentication = AuthenticationTokenFactory.create(auth)
+        val accessTokenExpiration = valueConfig.accessTokenExpired
+
+        return Token(
+            accessToken =
+                jwtTokenIssuer.generateToken(
+                    authentication = authentication,
+                    expiration = accessTokenExpiration,
                 ),
         )
     }

--- a/src/main/kotlin/com/terning/server/kotlin/domain/common/security/jwt/auth/AuthenticationTokenFactory.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/domain/common/security/jwt/auth/AuthenticationTokenFactory.kt
@@ -1,7 +1,7 @@
 package com.terning.server.kotlin.domain.common.security.jwt.auth
 
-import com.terning.server.kotlin.domain.user.User
+import com.terning.server.kotlin.domain.auth.Auth
 
 object AuthenticationTokenFactory {
-    fun create(user: User): UserAuthentication = UserAuthentication(user.id)
+    fun create(auth: Auth): UserAuthentication = UserAuthentication(auth.user.id)
 }

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -100,7 +100,7 @@ class AuthController(
         return ResponseEntity.ok(
             ApiResponse.success(
                 status = HttpStatus.OK,
-                message = "토근 재발급에 성공하였습니다.",
+                message = "토큰 재발급에 성공하였습니다.",
                 result = response,
             ),
         )

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AuthController.kt
@@ -5,6 +5,7 @@ import com.terning.server.kotlin.application.auth.dto.SignInRequest
 import com.terning.server.kotlin.application.auth.dto.SignInResponse
 import com.terning.server.kotlin.application.auth.dto.SignUpRequest
 import com.terning.server.kotlin.application.auth.dto.SignUpResponse
+import com.terning.server.kotlin.application.auth.dto.TokenReissueResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -86,6 +87,21 @@ class AuthController(
                 status = HttpStatus.OK,
                 message = "계정탈퇴에 성공하였습니다.",
                 result = Unit,
+            ),
+        )
+    }
+
+    @PostMapping("/token-reissue")
+    fun tokenReissue(
+        @RequestHeader("Authorization") refreshToken: String,
+    ): ResponseEntity<ApiResponse<TokenReissueResponse>> {
+        val response = authService.tokenReissue(refreshToken)
+
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "토근 재발급에 성공하였습니다.",
+                result = response,
             ),
         )
     }

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -44,6 +44,7 @@ class AuthServiceTest {
     private val authId = "123456"
     private val kakaoProvider = mockk<SocialAuthProvider>()
     private val profileImage = ProfileImage.LUCKY.value
+    private val userId = 1L
 
     @BeforeEach
     fun setup() {
@@ -163,7 +164,6 @@ class AuthServiceTest {
         @Test
         fun `로그아웃 시 유저의 리프레시 토큰을 초기화한다`() {
             // given
-            val userId = 1L
             val mockAuth = mockk<Auth>(relaxed = true)
             every { authRepository.findByUserId(userId) } returns mockAuth
 
@@ -181,7 +181,6 @@ class AuthServiceTest {
         @Test
         fun `회원탈퇴 시 유저의 정보를 지운다`() {
             // given
-            val userId = 1L
             val user = mockk<User>()
 
             every { userRepository.findById(userId) } returns Optional.of(user)
@@ -192,6 +191,30 @@ class AuthServiceTest {
 
             // then
             verify(exactly = 1) { userRepository.delete(user) }
+        }
+    }
+
+    @Nested
+    @DisplayName("tokenReissue 메소드는")
+    inner class TokenReissue {
+        @Test
+        fun `리프레시 토큰으로 액세스 토큰을 재발급받는다`() {
+            // given
+            val refreshToken = "oldRefreshToken"
+            val refreshTokenVo = RefreshToken.from(refreshToken)
+            val auth = mockk<Auth>(relaxed = true)
+            val jwtToken = Token(accessToken = "newAccessToken")
+
+            every { authRepository.findByRefreshToken(refreshTokenVo) } returns auth
+            every { jwtTokenManager.issueAccessToken(auth) } returns jwtToken
+
+            // when
+            val result = authService.tokenReissue(refreshToken)
+
+            // then
+            assertEquals("newAccessToken", result.accessToken)
+            verify(exactly = 1) { authRepository.findByRefreshToken(refreshTokenVo) }
+            verify(exactly = 1) { jwtTokenManager.issueAccessToken(auth) }
         }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -104,7 +104,7 @@ class AuthServiceTest {
             every { socialAuthServiceManager.getAuthService(authType) } returns kakaoProvider
             every { kakaoProvider.getAuthId(accessToken) } returns authId
             every { authRepository.findByAuthIdAndAuthType(authIdVo, authType) } returns auth
-            every { jwtTokenManager.generateToken(user) } returns token
+            every { jwtTokenManager.generateToken(auth) } returns token
             every { auth.updateRefreshToken(any()) } just Runs
 
             // when

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -7,6 +7,7 @@ import com.terning.server.kotlin.application.auth.dto.SignInRequest
 import com.terning.server.kotlin.application.auth.dto.SignInResponse
 import com.terning.server.kotlin.application.auth.dto.SignUpRequest
 import com.terning.server.kotlin.application.auth.dto.SignUpResponse
+import com.terning.server.kotlin.application.auth.dto.TokenReissueResponse
 import com.terning.server.kotlin.config.TestSecurityConfig
 import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.Token
@@ -154,5 +155,28 @@ class AuthControllerTest {
         }
 
         verify { authService.withdraw(1L) }
+    }
+
+    @Test
+    fun `리프레시 토큰으로 액세스 토큰을 재발급받는다`() {
+        // given
+        val refreshToken = "Bearer oldRefreshToken"
+        val tokenReissueResponse =
+            TokenReissueResponse(
+                accessToken = "newAccessToken",
+            )
+
+        every { authService.tokenReissue(refreshToken) } returns tokenReissueResponse
+
+        // when & then
+        mockMvc.post("/api/v1/auth/token-reissue") {
+            header("Authorization", refreshToken)
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.message") { value("토근 재발급에 성공하였습니다.") }
+            jsonPath("$.result.accessToken") { value("newAccessToken") }
+        }
+
+        verify(exactly = 1) { authService.tokenReissue(refreshToken) }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -173,7 +173,7 @@ class AuthControllerTest {
             header("Authorization", refreshToken)
         }.andExpect {
             status { isOk() }
-            jsonPath("$.message") { value("토근 재발급에 성공하였습니다.") }
+            jsonPath("$.message") { value("토큰 재발급에 성공하였습니다.") }
             jsonPath("$.result.accessToken") { value("newAccessToken") }
         }
 


### PR DESCRIPTION
# 📄 Work Description  
- 토큰 재발급 API 구현했습니다.
- 기존에 있던 `jwtTokenManager`로 토큰을 재발급 하였습니다.
- Service와 Controller에 해당하는 테스트 코드를 각각 작성했습니다.

# 💭 Thoughts 
- JwtTokenManager 클래스에 있는 메소드들의 매개변수 타입을 User에서 Auth로 변경했습니다.
    - 이렇게 변경한 이유는 생각해보니까 토큰은 Auth 엔티티에 있는 속성인데 굳이 User로 타입을 받을 이유가 없다고 생각했기 때문입니다. 
    - 괜찮은 변경인지 의문이 들긴하는데 어떻게 생각하시나욥..

# ✅ Testing Result  
<img width="484" alt="image" src="https://github.com/user-attachments/assets/119b5f21-652d-4a97-b034-5aea2c143dde" />
<img width="480" alt="image" src="https://github.com/user-attachments/assets/3338f46e-3fe1-4a83-b0b9-2df749e6710e" />


# 🗂 Related Issue  
- closed #134
