### PR TITLE
[♻️ refactor] 컨트롤러에 @AuthenticationPrincipal을 사용하여 인증된 사용자 ID 연동

### DIFF
--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -58,14 +58,7 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: 테스트 프로필로 Gradle 빌드 및 테스트 실행
-        run: |
-          ./gradlew build \
-            -Dspring.profiles.active=test \
-            -DSECRET_KEY=$SECRET_KEY \
-            -DKAKAO_URL=$KAKAO_URL \
-            -DAPPLE_URL=$APPLE_URL \
-            -DACCESS_TOKEN_EXPIRED=$ACCESS_TOKEN_EXPIRED \
-            -DREFRESH_TOKEN_EXPIRED=$REFRESH_TOKEN_EXPIRED
+        run: ./gradlew build -Dspring.profiles.active=test
 
       # GraalVM 네이티브 이미지 빌드를 위한 주석 처리된 단계
       # - name: Native Image Compile (Fail-safe)

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -58,14 +58,7 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: 테스트 프로필로 Gradle 빌드 및 테스트 실행
-        run: |
-          ./gradlew build \
-            -Dspring.profiles.active=test \
-            -DSECRET_KEY=${{ secrets.SECRET_KEY }} \
-            -DKAKAO_URL=${{ secrets.KAKAO_URL }} \
-            -DAPPLE_URL=${{ secrets.APPLE_URL }} \
-            -DACCESS_TOKEN_EXPIRED=${{ secrets.ACCESS_TOKEN_EXPIRED }} \
-            -DREFRESH_TOKEN_EXPIRED=${{ secrets.REFRESH_TOKEN_EXPIRED }}
+        run: ./gradlew build -Dspring.profiles.active=test
 
       # GraalVM 네이티브 이미지 빌드를 위한 주석 처리된 단계
       # - name: Native Image Compile (Fail-safe)

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -3,11 +3,20 @@ name: DEV-CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-22.04
 
+    permissions:
+      contents: read
+      pull-requests: read
+
     env:
+      TZ: 'Asia/Seoul'
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       KAKAO_URL: ${{ secrets.KAKAO_URL }}
       APPLE_URL: ${{ secrets.APPLE_URL }}
@@ -15,17 +24,17 @@ jobs:
       REFRESH_TOKEN_EXPIRED: ${{ secrets.REFRESH_TOKEN_EXPIRED }}
 
     steps:
-      - name: 체크아웃
-        uses: actions/checkout@v3
+      - name: 저장소 코드 체크아웃
+        uses: actions/checkout@v4
 
-      # GraalVM 설정 대신 일반 JDK를 사용하도록 수정
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
 
-      # - name: Set up GraalVM JDK 21 with native-image  
+      # GraalVM 네이티브 이미지 빌드를 위한 주석 처리된 설정
+      # - name: Set up GraalVM JDK 21 with native-image
       #   uses: graalvm/setup-graalvm@v1.1.1
       #   with:
       #     distribution: 'graalvm-community'
@@ -33,7 +42,7 @@ jobs:
       #     java-version: '21'
 
       - name: Gradle 캐시 설정
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -45,13 +54,14 @@ jobs:
       - name: Gradle 실행 권한 부여
         run: chmod +x ./gradlew
 
-      - name: Gradle Build & Test 실행
-        run: ./gradlew build
-
-      - name: ktlint 실행
+      - name: ktlint로 코드 스타일 검사
         run: ./gradlew ktlintCheck
 
-      # - name: Native Image Compile (Fail-safe)  
+      - name: 테스트 프로필로 Gradle 빌드 및 테스트 실행
+        run: ./gradlew build -Dspring.profiles.active=test
+
+      # GraalVM 네이티브 이미지 빌드를 위한 주석 처리된 단계
+      # - name: Native Image Compile (Fail-safe)
       #   continue-on-error: true
       #   run: |
       #     echo "::group::GraalVM Native Image Build"

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -58,7 +58,7 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: 테스트 프로필로 Gradle 빌드 및 테스트 실행
-        run: ./gradlew build -Dspring.profiles.active=test
+        run: ./gradlew build
 
       # GraalVM 네이티브 이미지 빌드를 위한 주석 처리된 단계
       # - name: Native Image Compile (Fail-safe)

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -58,7 +58,14 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: 테스트 프로필로 Gradle 빌드 및 테스트 실행
-        run: ./gradlew build -Dspring.profiles.active=test
+        run: |
+          ./gradlew build \
+            -Dspring.profiles.active=test \
+            -DSECRET_KEY=${{ secrets.SECRET_KEY }} \
+            -DKAKAO_URL=${{ secrets.KAKAO_URL }} \
+            -DAPPLE_URL=${{ secrets.APPLE_URL }} \
+            -DACCESS_TOKEN_EXPIRED=${{ secrets.ACCESS_TOKEN_EXPIRED }} \
+            -DREFRESH_TOKEN_EXPIRED=${{ secrets.REFRESH_TOKEN_EXPIRED }}
 
       # GraalVM 네이티브 이미지 빌드를 위한 주석 처리된 단계
       # - name: Native Image Compile (Fail-safe)

--- a/.github/workflows/DEV-CI.yml
+++ b/.github/workflows/DEV-CI.yml
@@ -58,7 +58,14 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: 테스트 프로필로 Gradle 빌드 및 테스트 실행
-        run: ./gradlew build -Dspring.profiles.active=test
+        run: |
+          ./gradlew build \
+            -Dspring.profiles.active=test \
+            -DSECRET_KEY=$SECRET_KEY \
+            -DKAKAO_URL=$KAKAO_URL \
+            -DAPPLE_URL=$APPLE_URL \
+            -DACCESS_TOKEN_EXPIRED=$ACCESS_TOKEN_EXPIRED \
+            -DREFRESH_TOKEN_EXPIRED=$REFRESH_TOKEN_EXPIRED
 
       # GraalVM 네이티브 이미지 빌드를 위한 주석 처리된 단계
       # - name: Native Image Compile (Fail-safe)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.10")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("org.springframework.security:spring-security-core")
 }
 
 kapt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.10")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.springframework.security:spring-security-core")
 }
 
 kapt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.10")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 kapt {

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/AnnouncementController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/AnnouncementController.kt
@@ -4,6 +4,7 @@ import com.terning.server.kotlin.application.announcement.AnnouncementService
 import com.terning.server.kotlin.application.announcement.dto.DetailAnnouncementResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -16,11 +17,9 @@ class AnnouncementController(
 ) {
     @GetMapping("/{internshipAnnouncementId}")
     fun getDetailInternshipAnnouncement(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @PathVariable internshipAnnouncementId: Long,
     ): ResponseEntity<ApiResponse<DetailAnnouncementResponse>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         val response =
             announcementService.getDetailAnnouncement(
                 userId = userId,

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/CalendarController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/CalendarController.kt
@@ -7,6 +7,7 @@ import com.terning.server.kotlin.application.calendar.dto.MonthlyViewResponse
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -20,10 +21,9 @@ class CalendarController(
 ) {
     @GetMapping("/daily")
     fun getDailyScraps(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
     ): ResponseEntity<ApiResponse<List<DailyScrapsResponse>>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 교체
         val dailyScrapsResponse = calendarService.getDailyScraps(userId, date)
         return ResponseEntity.ok(
             ApiResponse.success(
@@ -36,11 +36,10 @@ class CalendarController(
 
     @GetMapping("/monthly-list")
     fun getDetailedMonthlyScraps(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @RequestParam("year") year: Int,
         @RequestParam("month") month: Int,
     ): ResponseEntity<ApiResponse<List<DetailedMonthlyScrapsResponse>>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
         val detailedMonthlyScrapsResponse = calendarService.getDetailedMonthlyScraps(userId, year, month)
         return ResponseEntity.ok(
             ApiResponse.success(
@@ -53,11 +52,10 @@ class CalendarController(
 
     @GetMapping("/monthly-default")
     fun getMonthlyScraps(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @RequestParam("year") year: Int,
         @RequestParam("month") month: Int,
     ): ResponseEntity<ApiResponse<MonthlyViewResponse>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
         val monthlyViewResponse = calendarService.getMonthlyScraps(userId, year, month)
         return ResponseEntity.ok(
             ApiResponse.success(

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/FilterController.kt
@@ -6,6 +6,7 @@ import com.terning.server.kotlin.application.filter.dto.GetFilterResponse
 import com.terning.server.kotlin.application.filter.dto.UpdateFilterRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -20,11 +21,9 @@ class FilterController(
 ) {
     @PostMapping("auth/sign-up/filter")
     fun createUserFilter(
-        // TODO : @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @RequestBody createFilterRequest: CreateFilterRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         filterService.createUserFilter(
             userId = userId,
             createFilterRequest = createFilterRequest,
@@ -41,10 +40,8 @@ class FilterController(
 
     @GetMapping("filters")
     fun getUserFilter(
-        // TODO : @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<GetFilterResponse>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         val response = filterService.getUserFilter(userId)
 
         return ResponseEntity.ok(
@@ -58,11 +55,9 @@ class FilterController(
 
     @PutMapping("filters")
     fun updateUserFilter(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @RequestBody updateFilterRequest: UpdateFilterRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         filterService.updateUserFilter(
             userId = userId,
             updateFilterRequest = updateFilterRequest,

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/HomeController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/HomeController.kt
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -19,17 +20,14 @@ class HomeController(
 ) {
     @GetMapping
     fun getInternshipAnnouncementsFilteredByUserFilter(
-        // TODO: 실제 로그인된 사용자의 인증 정보 주입 필요
-        // @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @RequestParam(name = "sortBy", required = false, defaultValue = "deadlineSoon")
         sortingCondition: String,
         @PageableDefault(size = 10) pageable: Pageable,
     ): ResponseEntity<ApiResponse<HomeResponse>> {
-        val authenticatedUserId: Long = 1L // TODO: 인증 시스템 연동 시 실제 유저 ID로 대체
-
         val internshipAnnouncementResponse: HomeResponse =
             homeService.getFilteredAnnouncements(
-                userId = authenticatedUserId,
+                userId = userId,
                 sortBy = sortingCondition,
                 pageable = pageable,
             )
@@ -45,9 +43,8 @@ class HomeController(
 
     @GetMapping("/upcoming")
     fun getUpcomingDeadlineScraps(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<UpcomingDeadlineScrapResponse>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 교체
         val response = homeService.findUpcomingDeadlineScraps(userId)
 
         return ResponseEntity.ok(

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/MyPageController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/MyPageController.kt
@@ -5,6 +5,7 @@ import com.terning.server.kotlin.application.mypage.ProfileRequest
 import com.terning.server.kotlin.application.mypage.ProfileResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,30 +19,24 @@ class MyPageController(
 ) {
     @GetMapping("/profile")
     fun getProfile(
-        // TODO : @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<ProfileResponse>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         val response = mypageService.getUserProfile(userId)
 
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(
-                ApiResponse.success(
-                    status = HttpStatus.OK,
-                    message = "마이페이지 > 프로필 정보 불러오기를 성공했습니다",
-                    result = response,
-                ),
-            )
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                status = HttpStatus.OK,
+                message = "마이페이지 > 프로필 정보 불러오기를 성공했습니다",
+                result = response,
+            ),
+        )
     }
 
     @PatchMapping("/profile")
     fun updateProfile(
-        // TODO : @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @RequestBody profileRequest: ProfileRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         mypageService.updateUserProfile(
             userId = userId,
             profileRequest = profileRequest,

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/ScrapController.kt
@@ -5,6 +5,7 @@ import com.terning.server.kotlin.application.scrap.dto.ScrapRequest
 import com.terning.server.kotlin.application.scrap.dto.ScrapUpdateRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -20,12 +21,10 @@ class ScrapController(
 ) {
     @PostMapping("/{internshipAnnouncementId}")
     fun scrap(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @PathVariable internshipAnnouncementId: Long,
         @RequestBody scrapRequest: ScrapRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         scrapService.scrap(
             userId = userId,
             internshipAnnouncementId = internshipAnnouncementId,
@@ -45,12 +44,10 @@ class ScrapController(
 
     @PatchMapping("/{internshipAnnouncementId}")
     fun updateScrap(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @PathVariable internshipAnnouncementId: Long,
         @RequestBody scrapUpdateRequest: ScrapUpdateRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         scrapService.updateScrap(
             userId = userId,
             internshipAnnouncementId = internshipAnnouncementId,
@@ -68,11 +65,9 @@ class ScrapController(
 
     @DeleteMapping("/{internshipAnnouncementId}")
     fun cancelScrap(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @PathVariable internshipAnnouncementId: Long,
     ): ResponseEntity<ApiResponse<Unit>> {
-        val userId: Long = 1 // 임시 userId
-
         scrapService.cancelScrap(
             userId = userId,
             internshipAnnouncementId = internshipAnnouncementId,

--- a/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
+++ b/src/main/kotlin/com/terning/server/kotlin/ui/api/SearchController.kt
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -21,13 +22,11 @@ class SearchController(
 ) {
     @GetMapping
     fun search(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
         @RequestParam(required = false) keyword: String?,
         @RequestParam(defaultValue = "DEADLINE_SOON") sortBy: String,
         @PageableDefault(size = 10) pageable: Pageable,
     ): ResponseEntity<ApiResponse<SearchPageResponse>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         val response =
             searchService.search(
                 userId = userId,
@@ -47,10 +46,8 @@ class SearchController(
 
     @GetMapping("/views")
     fun getMostViewedAnnouncements(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<ViewCountResponse>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         val response = searchService.getMostViewedAnnouncements(userId)
 
         return ResponseEntity.ok(
@@ -64,10 +61,8 @@ class SearchController(
 
     @GetMapping("/scraps")
     fun getMostScrappedAnnouncements(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<ScrapCountResponse>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         val response = searchService.getMostScrappedAnnouncements(userId)
 
         return ResponseEntity.ok(
@@ -81,10 +76,8 @@ class SearchController(
 
     @GetMapping("/banners")
     fun getBanners(
-        // TODO: @AuthenticationPrincipal userId: Long,
+        @AuthenticationPrincipal userId: Long,
     ): ResponseEntity<ApiResponse<BannersView>> {
-        val userId: Long = 1 // TODO: @AuthenticationPrincipal 구현 시 제거
-
         val response = searchService.getBanners(userId)
 
         return ResponseEntity.ok(

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,3 +23,11 @@ spring:
 
 server:
   port: ${SERVER_PORT_LOCAL}
+
+
+jwt:
+  secret-key: ${SECRET_KEY}
+  kakao-url: ${KAKAO_URL}
+  apple-url: ${APPLE_URL}
+  access-token-expired: ${ACCESS_TOKEN_EXPIRED}
+  refresh-token-expired: ${REFRESH_TOKEN_EXPIRED}

--- a/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/application/auth/AuthServiceTest.kt
@@ -165,12 +165,13 @@ class AuthServiceTest {
             val userId = 1L
             val mockAuth = mockk<Auth>(relaxed = true)
             every { authRepository.findByUserId(userId) } returns mockAuth
+            every { mockAuth.resetRefreshToken() } just Runs
 
             // when
             authService.signOut(userId)
 
             // then
-            verify { mockAuth.resetRefreshToken() }
+            verify(exactly = 1) { mockAuth.resetRefreshToken() }
         }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/support/WithMockCustomUser.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/support/WithMockCustomUser.kt
@@ -1,0 +1,10 @@
+package com.terning.server.kotlin.support
+
+import org.springframework.security.test.context.support.WithSecurityContext
+import kotlin.annotation.AnnotationRetention.RUNTIME
+
+@Retention(RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory::class)
+annotation class WithMockCustomUser(
+    val userId: Long = 1L,
+)

--- a/src/test/kotlin/com/terning/server/kotlin/support/WithMockCustomUserSecurityContextFactory.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/support/WithMockCustomUserSecurityContextFactory.kt
@@ -1,0 +1,16 @@
+package com.terning.server.kotlin.support
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+
+class WithMockCustomUserSecurityContextFactory : WithSecurityContextFactory<WithMockCustomUser> {
+    override fun createSecurityContext(annotation: WithMockCustomUser): SecurityContext {
+        val context = SecurityContextHolder.createEmptyContext()
+        val principal = annotation.userId
+        val auth = UsernamePasswordAuthenticationToken(principal, "", emptyList())
+        context.authentication = auth
+        return context
+    }
+}

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AnnouncementControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AnnouncementControllerTest.kt
@@ -3,18 +3,20 @@ package com.terning.server.kotlin.ui.api
 import com.ninjasquad.springmockk.MockkBean
 import com.terning.server.kotlin.application.announcement.AnnouncementService
 import com.terning.server.kotlin.application.announcement.dto.DetailAnnouncementResponse
+import com.terning.server.kotlin.config.TestSecurityConfig
+import com.terning.server.kotlin.support.WithMockCustomUser
 import io.mockk.every
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @WebMvcTest(AnnouncementController::class)
-@WithMockUser
+@Import(TestSecurityConfig::class)
 @ActiveProfiles("test")
 class AnnouncementControllerTest {
     @Autowired
@@ -25,6 +27,7 @@ class AnnouncementControllerTest {
 
     @Test
     @DisplayName("사용자가 원하는 특정 인턴공고 상세 페이지를 조회한다")
+    @WithMockCustomUser(userId = 1L)
     fun getDetailInternshipAnnouncement() {
         // given
         val internshipAnnouncementId = 1L

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -10,17 +10,17 @@ import com.terning.server.kotlin.application.auth.dto.SignUpResponse
 import com.terning.server.kotlin.config.TestSecurityConfig
 import com.terning.server.kotlin.domain.auth.vo.AuthType
 import com.terning.server.kotlin.domain.auth.vo.Token
+import com.terning.server.kotlin.support.WithMockCustomUser
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
@@ -40,7 +40,8 @@ class AuthControllerTest {
     lateinit var objectMapper: ObjectMapper
 
     @Test
-    fun `유저를 로그인한다`() {
+    @DisplayName("소셜 로그인을 통해 서비스에 로그인한다")
+    fun signInUser() {
         // given
         val accessTokenHeader = "Bearer dummyKakaoToken"
         val request =
@@ -58,7 +59,7 @@ class AuthControllerTest {
 
         every {
             authService.signInUser(
-                eq("Bearer dummyKakaoToken"),
+                eq(accessTokenHeader),
                 any(),
             )
         } returns response
@@ -81,7 +82,8 @@ class AuthControllerTest {
     }
 
     @Test
-    fun `유저를 회원가입한다`() {
+    @DisplayName("소셜 로그인을 통해 서비스에 회원가입한다")
+    fun signUpUser() {
         // given
         val request =
             SignUpRequest(
@@ -119,20 +121,21 @@ class AuthControllerTest {
     }
 
     @Test
-    fun `유저를 로그아웃한다`() {
+    @DisplayName("로그인된 유저를 로그아웃한다")
+    @WithMockCustomUser(userId = 1L)
+    fun logoutUser() {
         // given
-        val authentication = UsernamePasswordAuthenticationToken(1L, null, emptyList())
-        SecurityContextHolder.getContext().authentication = authentication
-
-        every { authService.signOut(1L) } just Runs
+        val userId = 1L
+        every { authService.signOut(userId) } just Runs
 
         // when & then
-        mockMvc.post("/api/v1/auth/logout")
-            .andExpect {
-                status { isOk() }
-                jsonPath("$.message") { value("로그아웃에 성공하였습니다.") }
-            }
+        mockMvc.post("/api/v1/auth/logout") {
+            with(csrf())
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.message") { value("로그아웃에 성공하였습니다.") }
+        }
 
-        verify { authService.signOut(1L) }
+        verify(exactly = 1) { authService.signOut(userId) }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -22,6 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/AuthControllerTest.kt
@@ -125,8 +125,7 @@ class AuthControllerTest {
     @WithMockCustomUser(userId = 1L)
     fun logoutUser() {
         // given
-        val userId = 1L
-        every { authService.signOut(userId) } just Runs
+        every { authService.signOut(1L) } just Runs
 
         // when & then
         mockMvc.post("/api/v1/auth/logout") {
@@ -136,6 +135,6 @@ class AuthControllerTest {
             jsonPath("$.message") { value("로그아웃에 성공하였습니다.") }
         }
 
-        verify(exactly = 1) { authService.signOut(userId) }
+        verify(exactly = 1) { authService.signOut(1L) }
     }
 }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/CalendarControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/CalendarControllerTest.kt
@@ -5,14 +5,16 @@ import com.terning.server.kotlin.application.calendar.CalendarService
 import com.terning.server.kotlin.application.calendar.dto.DailyScrapsResponse
 import com.terning.server.kotlin.application.calendar.dto.DetailedMonthlyScrapsResponse
 import com.terning.server.kotlin.application.calendar.dto.MonthlyViewResponse
+import com.terning.server.kotlin.config.TestSecurityConfig
 import com.terning.server.kotlin.domain.internshipAnnouncement.InternshipAnnouncement
+import com.terning.server.kotlin.support.WithMockCustomUser
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -21,7 +23,7 @@ import java.time.LocalDate
 import java.time.ZoneId
 
 @WebMvcTest(CalendarController::class)
-@WithMockUser
+@Import(TestSecurityConfig::class)
 @ActiveProfiles("test")
 class CalendarControllerTest {
     @Autowired
@@ -32,6 +34,7 @@ class CalendarControllerTest {
 
     @Test
     @DisplayName("일간 스크랩 데이터를 조회한다")
+    @WithMockCustomUser(userId = 1L)
     fun getDailyScraps() {
         // given
         val userId = 1L
@@ -73,6 +76,7 @@ class CalendarControllerTest {
 
     @Test
     @DisplayName("월간 스크랩 데이터를 리스트 형태로 조회한다")
+    @WithMockCustomUser(userId = 1L)
     fun getDetailedMonthlyScraps() {
         // given
         val userId = 1L
@@ -116,6 +120,7 @@ class CalendarControllerTest {
 
     @Test
     @DisplayName("월간 스크랩 데이터를 기본 형태로 조회한다")
+    @WithMockCustomUser(userId = 1L)
     fun getMonthlyScraps() {
         // given
         val userId = 1L

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/FilterControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/FilterControllerTest.kt
@@ -7,6 +7,7 @@ import com.terning.server.kotlin.application.filter.dto.CreateFilterRequest
 import com.terning.server.kotlin.application.filter.dto.GetFilterResponse
 import com.terning.server.kotlin.application.filter.dto.UpdateFilterRequest
 import com.terning.server.kotlin.config.TestSecurityConfig
+import com.terning.server.kotlin.support.WithMockCustomUser
 import io.mockk.every
 import io.mockk.just
 import io.mockk.runs
@@ -17,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -73,6 +75,7 @@ class FilterControllerTest {
 
     @Test
     @DisplayName("필터링 정보를 생성한다")
+    @WithMockCustomUser(userId = 1L)
     fun createUserFilter() {
         // given
         every {
@@ -86,6 +89,7 @@ class FilterControllerTest {
         mockMvc.post("/api/v1/auth/sign-up/filter") {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(createFilterRequest)
+            with(csrf())
         }.andExpect {
             // then
             status { isOk() }
@@ -94,6 +98,7 @@ class FilterControllerTest {
 
     @Test
     @DisplayName("필터링 정보를 가져온다")
+    @WithMockCustomUser(userId = 1L)
     fun getFilter() {
         // given
         every { filterService.getUserFilter(userId = userId) } returns getFilterResponse
@@ -114,6 +119,7 @@ class FilterControllerTest {
 
     @Test
     @DisplayName("사용자가 요청한 필터링 정보를 저장한다")
+    @WithMockCustomUser(userId = 1L)
     fun updateUserFilter() {
         // given
         every {
@@ -127,6 +133,7 @@ class FilterControllerTest {
         mockMvc.put("/api/v1/filters") {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(updateFilterRequest)
+            with(csrf())
         }.andExpect {
             // then
             status { isOk() }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/HomeControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/HomeControllerTest.kt
@@ -4,20 +4,22 @@ import com.ninjasquad.springmockk.MockkBean
 import com.terning.server.kotlin.application.home.HomeService
 import com.terning.server.kotlin.application.home.dto.Home
 import com.terning.server.kotlin.application.home.dto.HomeResponse
+import com.terning.server.kotlin.config.TestSecurityConfig
+import com.terning.server.kotlin.support.WithMockCustomUser
 import io.mockk.every
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
-import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @WebMvcTest(HomeController::class)
-@WithMockUser
+@Import(TestSecurityConfig::class)
 @ActiveProfiles("test")
 class HomeControllerTest {
     @Autowired
@@ -28,6 +30,7 @@ class HomeControllerTest {
 
     @Test
     @DisplayName("필터링 조건에 맞는 인턴 공고를 조회한다")
+    @WithMockCustomUser(userId = 1L)
     fun getInternshipAnnouncementsFilteredByUserFilter() {
         // given
         val pageable: Pageable = PageRequest.of(0, 10)
@@ -56,6 +59,8 @@ class HomeControllerTest {
         // when & then
         mockMvc.get("/api/v1/home") {
             param("sortBy", sortBy)
+            param("page", "0")
+            param("size", "10")
         }.andExpect {
             status { isOk() }
             jsonPath("$.status") { value(200) }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/MyPageControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/MyPageControllerTest.kt
@@ -6,6 +6,7 @@ import com.terning.server.kotlin.application.mypage.MyPageService
 import com.terning.server.kotlin.application.mypage.ProfileRequest
 import com.terning.server.kotlin.application.mypage.ProfileResponse
 import com.terning.server.kotlin.config.TestSecurityConfig
+import com.terning.server.kotlin.support.WithMockCustomUser
 import io.mockk.every
 import io.mockk.just
 import io.mockk.runs
@@ -16,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -54,6 +56,7 @@ class MyPageControllerTest {
 
     @Test
     @DisplayName("유저 정보를 가져온다")
+    @WithMockCustomUser(userId = 1L)
     fun getProfile() {
         // given
         val userId = 1L
@@ -64,7 +67,7 @@ class MyPageControllerTest {
             contentType = MediaType.APPLICATION_JSON
         }.andExpect {
             // then
-            status { isCreated() }
+            status { isOk() }
             jsonPath("$.result.name") { value("이유빈") }
             jsonPath("$.result.profileImage") { value("BASIC") }
             jsonPath("$.result.authType") { value("KAKAO") }
@@ -73,6 +76,7 @@ class MyPageControllerTest {
 
     @Test
     @DisplayName("유저 정보를 수정한다")
+    @WithMockCustomUser(userId = 1L)
     fun updateProfile() {
         // given
         val userId = 1L
@@ -87,6 +91,7 @@ class MyPageControllerTest {
         mockMvc.patch("/api/v1/mypage/profile") {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(profileRequest)
+            with(csrf())
         }.andExpect {
             // then
             status { isOk() }

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/ScrapControllerTest.kt
@@ -6,6 +6,7 @@ import com.terning.server.kotlin.application.scrap.ScrapService
 import com.terning.server.kotlin.application.scrap.dto.ScrapRequest
 import com.terning.server.kotlin.application.scrap.dto.ScrapUpdateRequest
 import com.terning.server.kotlin.config.TestSecurityConfig
+import com.terning.server.kotlin.support.WithMockCustomUser
 import io.mockk.every
 import io.mockk.just
 import io.mockk.runs
@@ -46,6 +47,7 @@ class ScrapControllerTest {
 
     @Test
     @DisplayName("스크랩을 생성한다")
+    @WithMockCustomUser(userId = 1L)
     fun createScrap() {
         // given
         val internshipAnnouncementId = 1L
@@ -65,6 +67,7 @@ class ScrapControllerTest {
 
     @Test
     @DisplayName("스크랩 색상을 업데이트한다")
+    @WithMockCustomUser(userId = 1L)
     fun updateScrap() {
         // given
         val internshipAnnouncementId = 1L
@@ -84,6 +87,7 @@ class ScrapControllerTest {
 
     @Test
     @DisplayName("스크랩을 취소한다")
+    @WithMockCustomUser(userId = 1L)
     fun cancelScrap() {
         // given
         val internshipAnnouncementId = 1L

--- a/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
+++ b/src/test/kotlin/com/terning/server/kotlin/ui/api/SearchControllerTest.kt
@@ -10,19 +10,21 @@ import com.terning.server.kotlin.application.search.dto.SearchAnnouncementRespon
 import com.terning.server.kotlin.application.search.dto.SearchPageResponse
 import com.terning.server.kotlin.application.search.dto.ViewCountAnnouncementResponse
 import com.terning.server.kotlin.application.search.dto.ViewCountResponse
+import com.terning.server.kotlin.config.TestSecurityConfig
+import com.terning.server.kotlin.support.WithMockCustomUser
 import io.mockk.every
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageRequest
-import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @WebMvcTest(SearchController::class)
-@WithMockUser
+@Import(TestSecurityConfig::class)
 @ActiveProfiles("test")
 class SearchControllerTest {
     @Autowired
@@ -33,6 +35,7 @@ class SearchControllerTest {
 
     @Test
     @DisplayName("키워드로 공고를 검색하고 성공적으로 결과를 반환한다")
+    @WithMockCustomUser(userId = 1L)
     fun searchSuccessfully() {
         // given
         val userId = 1L
@@ -82,6 +85,7 @@ class SearchControllerTest {
 
     @Test
     @DisplayName("파라미터 없이 요청 시 기본값으로 검색하고 결과를 반환한다")
+    @WithMockCustomUser(userId = 1L)
     fun searchWithDefaultParameters() {
         // given
         val userId = 1L
@@ -124,6 +128,7 @@ class SearchControllerTest {
 
     @Test
     @DisplayName("조회수 많은 공고를 성공적으로 조회한다")
+    @WithMockCustomUser(userId = 1L)
     fun getMostViewedAnnouncementsSuccessfully() {
         // given
         val userId = 1L
@@ -160,6 +165,7 @@ class SearchControllerTest {
 
     @Test
     @DisplayName("스크랩 많은 공고를 성공적으로 조회한다")
+    @WithMockCustomUser(userId = 1L)
     fun getMostScrappedAnnouncementsSuccessfully() {
         // given
         val userId = 1L
@@ -196,6 +202,7 @@ class SearchControllerTest {
 
     @Test
     @DisplayName("배너를 성공적으로 조회한다")
+    @WithMockCustomUser(userId = 1L)
     fun getBannersSuccessfully() {
         // given
         val userId = 1L


### PR DESCRIPTION
# 📄 Work Description  
- `@AuthenticationPrincipal` 적용: 모든 컨트롤러에서 하드코딩 되어있던 userId를 제거하고, Spring Security의 `@AuthenticationPrincipal`을 통해 동적으로 인증된 사용자 ID를 받아오도록 수정했습니다.
- spring-security-test 의존성 추가: 컨트롤러 테스트에서 Spring Security 관련 기능을 사용하기 위해 build.gradle.kts에 의존성을 추가했습니다.
- 테스트용 커스텀 어노테이션 `@WithMockCustomUser` 추가: 컨트롤러 테스트 시, `@AuthenticationPrincipal`로 주입되는 Long 타입의 사용자 ID를 간단하게 모킹(Mocking)하기 위한 커스텀 어노테이션과 Security Context Factory를 구현했습니다.
- 컨트롤러 테스트 리팩토링: 새로운 인증 방식을 테스트하기 위해 모든 컨트롤러 테스트 코드에 `@WithMockCustomUser`를 적용하고 관련 로직을 수정했습니다.

# 💭 Thoughts 
- application 태스트를 제외하고 모두 통과하였는데요, 지난 회의에서 이야기를 나눴듯 auth 관련 이슈는 유빈님께서 해결해주시면 감사하겠습니다!
- `@WithMockCustomUser`를 만든 이유:
  - 컨트롤러에서 `@AuthenticationPrincipal` Long userId 형태로 사용자 ID를 직접 받고 있습니다. 하지만 Spring Security Test의 기본 `@WithMockUser`는 principal을 String 타입의 username으로 설정하여 저희 로직과 맞지 않았습니다.
  - 이를 해결하기 위해 principal로 Long 타입의 userId를 직접 설정해주는 `@WithMockCustomUser` 어노테이션을 만들어 테스트의 편의성과 코드의 일관성을 높였습니다.
- 유빈님, 이렇게 커스텀 어노테이션을 만들어 사용하면 앞으로 인증이 필요한 테스트를 작성할 때 더 편리할 것이라고 생각했는데, 어떻게 생각하시나요? 혹시 더 효율적이거나 표준적인 방법이 있다면 의견 공유해주시면 좋겠습니다!

# ✅ Testing Result  
![스크린샷 2025-06-26 오후 1 26 04](https://github.com/user-attachments/assets/d7548a08-8f5b-4259-8a77-67bcf1a83631)


# 🗂 Related Issue  
- closed #137 
